### PR TITLE
Ruby version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@
 config/database.yml
 
 *.swp
-.ruby-version


### PR DESCRIPTION
I noticed `.ruby-version` is in gitignore. I usually like checking in a `.ruby-version` (or something similar) as a way to communicate the 'blessed' Ruby version for a project. Downside is that the `.ruby-version` file is not very flexible so you have to have the *exact*  same version, while usually a minor version in the same major version will suffice as well.

How do we feel about this?