### PR TITLE
Add Atom feed with 25 last transactions

### DIFF
--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -1,0 +1,12 @@
+class FeedController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def index
+    request.format = :atom
+    @transactions = Transaction.order(updated_at: :desc).last(25)
+
+    respond_to do |format|
+      format.atom
+    end
+  end
+end

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -1,0 +1,14 @@
+atom_feed do |feed|
+  feed.title("#{root_url}: last 25 transactions")
+  feed.updated(@transactions.first.try(:updated_at))
+  feed.author do |author|
+    author.name "Kudo-o-matic"
+  end
+
+  @transactions.each do |transaction|
+    feed.entry(transaction, url: root_url) do |entry|
+      entry.title("New transaction on #{root_url}")
+      entry.summary("#{transaction.sender.name} awarded #{transaction.receiver_name} #{transaction.amount}₭ for #{transaction.activity_name}")
+    end
+  end
+end

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -8,7 +8,7 @@ atom_feed do |feed|
   @transactions.each do |transaction|
     feed.entry(transaction, url: root_url) do |entry|
       entry.title("New transaction on #{root_url}")
-      entry.summary("#{transaction.sender.name} awarded #{transaction.receiver_name} #{transaction.amount}₭ for #{transaction.activity_name}")
+      entry.summary("#{transaction.sender.name} awarded #{transaction.receiver_name} #{number_to_kudos(transaction.amount)} for #{transaction.activity_name}")
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
 
   get "minigames" => "minigames#index"
   get "minigames/kudosclicker" => "kudosclicker#index"
+  get "/feed", to: "feed#index"
 
   root 'dashboard#index'
 end

--- a/spec/integration/feed_spec.rb
+++ b/spec/integration/feed_spec.rb
@@ -25,7 +25,7 @@ describe "/feed", type: :request do
       transaction = @transactions.first
 
       expect(entry.title.content).to include("New transaction")
-      expect(entry.summary.content).to eq("#{transaction.sender.name} awarded #{transaction.receiver_name} #{transaction.amount}₭ for #{transaction.activity_name}")
+      expect(entry.summary.content).to eq("#{transaction.sender.name} awarded #{transaction.receiver_name} #{transaction.amount} ₭ for #{transaction.activity_name}")
     end
   end
 

--- a/spec/integration/feed_spec.rb
+++ b/spec/integration/feed_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "rss"
+
+describe "/feed", type: :request do
+  context "no transactions" do
+    it "produces an empty feed" do
+      expect(parse_feed).to be_empty
+    end
+  end
+
+  context "given many transactions" do
+    before do
+      @transactions = create_list(:transaction, 26)
+    end
+
+    it "includes last 25 entries" do
+      entries = parse_feed
+
+      expect(entries.size).to eq(25)
+      expect(entries.none?{|e| e.id.content.split("Transaction/")[1].to_i == @transactions.last.id}).to be true
+    end
+
+    it "includes basic info in entries" do
+      entry = parse_feed[0]
+      transaction = @transactions.first
+
+      expect(entry.title.content).to include("New transaction")
+      expect(entry.summary.content).to eq("#{transaction.sender.name} awarded #{transaction.receiver_name} #{transaction.amount}₭ for #{transaction.activity_name}")
+    end
+  end
+
+  def parse_feed
+    get "/feed"
+    RSS::Parser.parse(response.body).entries
+  end
+end


### PR DESCRIPTION
This PR adds a public Atom feed that contains the last 25 transactions.

This allows for simple integrations, like showing new transactions in Slack or showing last transactions on some dashboard etc.

Feed looks like this (note that 127.0.0.1:3000 is the root url where the application is deployed):

```xml

<?xml version="1.0" encoding="UTF-8"?>
<feed xml:lang="en-US" xmlns="http://www.w3.org/2005/Atom">
  <id>tag:127.0.0.1,2005:/feed</id>
  <link rel="alternate" type="text/html" href="http://127.0.0.1:3000"/>
  <link rel="self" type="application/atom+xml" href="http://127.0.0.1:3000/feed.xml"/>
  <title>http://127.0.0.1:3000/: last 25 transactions</title>
  <updated>2017-03-01T21:51:48Z</updated>
  <author>
    <name>Kudo-o-matic</name>
  </author>
  <entry>
    <id>tag:127.0.0.1,2005:Transaction/2</id>
    <published>2017-03-01T21:51:48Z</published>
    <updated>2017-03-01T21:51:48Z</updated>
    <link rel="alternate" type="text/html" href="http://127.0.0.1:3000/"/>
    <title>New transaction on http://127.0.0.1:3000/</title>
    <summary>Pascal Widdershoven awarded Someone 100₭ for being awesome</summary>
  </entry>
  <entry>
    <id>tag:127.0.0.1,2005:Transaction/1</id>
    <published>2017-03-01T21:51:39Z</published>
    <updated>2017-03-01T21:51:39Z</updated>
    <link rel="alternate" type="text/html" href="http://127.0.0.1:3000/"/>
    <title>New transaction on http://127.0.0.1:3000/</title>
    <summary>Pascal Widdershoven awarded Someone 5₭ for something awesome!</summary>
  </entry>
</feed>
```