### PR TITLE
Tweak feed output and simplify implementation

### DIFF
--- a/app/controllers/feed_controller.rb
+++ b/app/controllers/feed_controller.rb
@@ -3,7 +3,7 @@ class FeedController < ApplicationController
 
   def index
     request.format = :atom
-    @transactions = Transaction.order(updated_at: :desc).first(25)
+    @transactions = Transaction.last(25)
 
     respond_to do |format|
       format.atom

--- a/app/views/feed/index.atom.builder
+++ b/app/views/feed/index.atom.builder
@@ -1,13 +1,13 @@
 atom_feed do |feed|
-  feed.title("#{root_url}: last 25 transactions")
-  feed.updated(@transactions.first.try(:updated_at))
+  feed.title("Kudo-o-matic last 25 transactions")
+  feed.updated(@transactions.max_by(&:created_at).try(:created_at))
   feed.author do |author|
     author.name "Kudo-o-matic"
   end
 
   @transactions.each do |transaction|
-    feed.entry(transaction, url: root_url) do |entry|
-      entry.title("New transaction on #{root_url}")
+    feed.entry(transaction, url: root_url, updated: transaction.created_at) do |entry|
+      entry.title("New transaction on #{request.host}")
       entry.summary("#{transaction.sender.name} awarded #{transaction.receiver_name} #{number_to_kudos(transaction.amount)} for #{transaction.activity_name}")
     end
   end


### PR DESCRIPTION
* Don't care about showing newest first in feed, makes stuff easier.
* Set fixed feed title, don't include root_url which looks ugly
* Override updated timestamps so updates don't reappear in the feed