### PR TITLE
Fix go to top button safari

### DIFF
--- a/app/assets/stylesheets/components/_layout.scss
+++ b/app/assets/stylesheets/components/_layout.scss
@@ -85,7 +85,6 @@
   position: fixed;
   bottom: 2rem;
   right: 2rem;
-  width: fit-content !important;
 }
 
 @media screen and (max-width: 1200px) {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20170714064230) do
     t.string   "avatar_url"
     t.string   "slack_name"
     t.boolean  "admin",                  default: false
-    t.boolean  "mail_notifications",     default: false
+    t.boolean "mail_notifications"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree


### PR DESCRIPTION
Fixed the issue that caused the go-to-top button to appear too narrow in Safari.

Resolved #190 