### PR TITLE
Implemented image size reduction for images attached to transactions

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,7 +26,7 @@ module Admin
     end
 
     def destroy
-      if no_admin_left?
+      if User.find(params[:id]).admin? && no_admin_left?
         flash[:error] = "Last administrator can't be removed"
         redirect_back(fallback_location: admin_users_path)
       else

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -3,7 +3,8 @@ class Transaction < ActiveRecord::Base
   validates :activity_name_feed, length: { minimum: 4 }
 
   after_commit :send_slack_notification, on: :create, unless: :skip_callbacks
-  has_attached_file :image, styles: { small: "64x64", med: "100x100", large: "200x200" }
+  # also creates a second image file with a maximum width and/or height of 800 pixels with its aspect ratio preserved
+  has_attached_file :image, styles: {thumb: '600x600'}
   validates_attachment :image, content_type: { content_type: ["image/jpeg", "image/gif", "image/png"] }
   validates_with AttachmentSizeValidator, attributes: :image, less_than: 10.megabytes
 

--- a/app/views/transactions/_timeline.html.haml
+++ b/app/views/transactions/_timeline.html.haml
@@ -38,7 +38,9 @@
                   = "Attachment (#{transaction.image.size / 1000}kb)"
                 %span
                   %i.fa.fa-chevron-down.hide-file
-              = link_to image_tag(transaction.image.url(:thumb), class:'attachment-file'), transaction.image.url, target: '_blank'
+              -# checks whether or not the thumbnail exists so older posts (without thumb) will still be displayed
+              = link_to image_tag(transaction.image.exists?(:thumb) ? transaction.image.url(:thumb) : transaction.image,
+              class:'attachment-file'), transaction.image.url, target: '_blank'
       .transaction-footer-container
         - if current_user.voted_for? transaction
           = render 'unlikes', transaction: transaction

--- a/app/views/transactions/_timeline.html.haml
+++ b/app/views/transactions/_timeline.html.haml
@@ -35,10 +35,10 @@
             .media-attachment
               .img-file
                 %i.attachment-name
-                  = "Attachment (#{(transaction.image_file_size / 1000)}kb)"
+                  = "Attachment (#{transaction.image.size / 1000}kb)"
                 %span
                   %i.fa.fa-chevron-down.hide-file
-              = image_tag transaction.image.url, class:'attachment-file'
+              = link_to image_tag(transaction.image.url(:thumb), class:'attachment-file'), transaction.image.url, target: '_blank'
       .transaction-footer-container
         - if current_user.voted_for? transaction
           = render 'unlikes', transaction: transaction


### PR DESCRIPTION
Used the Paperclip gem to create a thumbnail image (reduced size) when a user submits a transaction with an image attached. The thumbnail image is now displayed on the timeline instead of the original image. When clicked, the original image gets displayed.