### PR TITLE
Added created_at and updated_at fields to API responses

### DIFF
--- a/app/resources/api/v1/balance_resource.rb
+++ b/app/resources/api/v1/balance_resource.rb
@@ -1,3 +1,4 @@
 class Api::V1::BalanceResource < Api::V1::BaseResource
-  attributes :current, :name
+  attributes :name, :current, :created_at, :updated_at
+  filters :name, :current, :created_at, :updated_at
 end

--- a/app/resources/api/v1/goal_resource.rb
+++ b/app/resources/api/v1/goal_resource.rb
@@ -1,5 +1,5 @@
 class Api::V1::GoalResource < Api::V1::BaseResource
-  attributes :achieved_on, :name, :amount
-  filters :name, :amount
+  attributes :name, :amount, :achieved_on, :created_at, :updated_at
+  filters :name, :amount, :achieved_on, :created_at, :updated_at
   has_one :balance
 end

--- a/app/views/api/v1/balances/balance.json.jbuilder
+++ b/app/views/api/v1/balances/balance.json.jbuilder
@@ -4,7 +4,9 @@ json.data do
   json.id @balance.id
   json.type 'balances'
   json.attributes do
-    json.current @balance.current
     json.name @balance.name
+    json.current @balance.current
+    json.created_at @balance.created_at
+    json.updated_at @balance.updated_at
   end
 end

--- a/app/views/api/v1/goals/goal.json.jbuilder
+++ b/app/views/api/v1/goals/goal.json.jbuilder
@@ -4,8 +4,10 @@ json.data do
   json.id @goal.id
   json.type 'goals'
   json.attributes do
-    json.achieved_on @goal.achieved_on
     json.name @goal.name
     json.amount @goal.amount
+    json.achieved_on @goal.achieved_on
+    json.created_at @goal.created_at
+    json.updated_at @goal.updated_at
   end
 end

--- a/spec/requests/api/v1/balances_controller_spec.rb
+++ b/spec/requests/api/v1/balances_controller_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                             self: "#{host}#{request}/#{balance1.id}"
                         },
                         attributes: {
+                            name: balance1.name,
                             current: balance1.current,
-                            name: balance1.name
+                            'created-at': to_api_timestamp_format(balance1.created_at),
+                            'updated-at': to_api_timestamp_format(balance1.updated_at)
                         }
                     },
                     {
@@ -41,8 +43,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                             self: "#{host}#{request}/#{balance2.id}"
                         },
                         attributes: {
+                            name: balance2.name,
                             current: balance1.current,
-                            name: balance2.name
+                            'created-at': to_api_timestamp_format(balance2.created_at),
+                            'updated-at': to_api_timestamp_format(balance2.updated_at)
                         }
                     }
                 ]
@@ -94,8 +98,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                         self: "#{host}#{request}"
                     },
                     attributes: {
+                        name: balance.name,
                         current: balance.current,
-                        name: balance.name
+                        'created-at': to_api_timestamp_format(balance.created_at),
+                        'updated-at': to_api_timestamp_format(balance.updated_at)
                     }
                 }
             }.with_indifferent_access
@@ -149,8 +155,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                         self: "#{host}#{request}/#{assigned_id}"
                     },
                     attributes: {
+                        name: balance.name,
                         current: balance.current,
-                        name: balance.name
+                        'created-at': assigned_created_at,
+                        'updated-at': assigned_updated_at
                     }
                 }
             }.with_indifferent_access
@@ -218,8 +226,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                           self: "#{host}#{request}"
                       },
                       attributes: {
+                          name: edited_name,
                           current: edited_current,
-                          name: edited_name
+                          'created-at': to_api_timestamp_format(balance.created_at),
+                          'updated-at': assigned_updated_at
                       }
                   }
               }.with_indifferent_access
@@ -256,8 +266,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                           self: "#{host}#{request}"
                       },
                       attributes: {
+                          name: balance.name,
                           current: balance.current,
-                          name: balance.name
+                          'created-at': to_api_timestamp_format(balance.created_at),
+                          'updated-at': to_api_timestamp_format(balance.updated_at)
                       }
                   }
               }.with_indifferent_access
@@ -354,8 +366,10 @@ RSpec.describe Api::V1::BalancesController, type: :request do
                     id: balance.id,
                     type: resource_type,
                     attributes: {
+                        name: balance.name,
                         current: balance.current,
-                        name: balance.name
+                        'created-at': to_api_timestamp_format(balance.created_at),
+                        'updated-at': to_api_timestamp_format(balance.updated_at)
                     }
                 }
             }.with_indifferent_access

--- a/spec/requests/api/v1/goals_controller_spec.rb
+++ b/spec/requests/api/v1/goals_controller_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                             self: "#{host}#{request}/#{goal1.id}"
                         },
                         attributes: {
-                            'achieved-on': goal1.achieved_on,
                             name: goal1.name,
-                            amount: goal1.amount
+                            amount: goal1.amount,
+                            'achieved-on': goal1.achieved_on,
+                            'created-at': to_api_timestamp_format(goal1.created_at),
+                            'updated-at': to_api_timestamp_format(goal1.updated_at)
                         },
                         relationships: {
                             balance: {
@@ -50,9 +52,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                             self: "#{host}#{request}/#{goal2.id}"
                         },
                         attributes: {
-                            'achieved-on': goal2.achieved_on,
                             name: goal2.name,
-                            amount: goal2.amount
+                            amount: goal2.amount,
+                            'achieved-on': goal2.achieved_on,
+                            'created-at': to_api_timestamp_format(goal2.created_at),
+                            'updated-at': to_api_timestamp_format(goal2.updated_at)
                         },
                         relationships: {
                             balance: {
@@ -110,9 +114,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                         self: "#{host}#{request}"
                     },
                     attributes: {
-                        'achieved-on': goal.achieved_on,
                         name: goal.name,
-                        amount: goal.amount
+                        amount: goal.amount,
+                        'achieved-on': goal.achieved_on,
+                        'created-at': to_api_timestamp_format(goal.created_at),
+                        'updated-at': to_api_timestamp_format(goal.updated_at)
                     },
                     relationships: {
                         balance: {
@@ -153,7 +159,6 @@ RSpec.describe Api::V1::GoalsController, type: :request do
   describe 'POST api/v1/goals' do
     let (:request) {'/api/v1/goals'}
     let! (:goal) {build(:goal)}
-    let (:assigned_id) {json['data']['id']}
 
     context 'with a valid api-token' do
       let (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
@@ -174,9 +179,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                         self: "#{host}#{request}/#{assigned_id}"
                     },
                     attributes: {
-                        'achieved-on': goal.achieved_on,
                         name: goal.name,
-                        amount: goal.amount
+                        amount: goal.amount,
+                        'achieved-on': goal.achieved_on,
+                        'created-at': assigned_created_at,
+                        'updated-at': assigned_updated_at
                     },
                     relationships: {
                         balance: {
@@ -246,9 +253,9 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                         type: 'goals',
                         id: goal.id,
                         attributes: {
-                            'achieved-on': edited_achieved_on,
                             name: edited_name,
-                            amount: edited_amount
+                            amount: edited_amount,
+                            'achieved-on': edited_achieved_on
                         }
                     }
                 }.to_json
@@ -264,9 +271,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                           self: "#{host}#{request}"
                       },
                       attributes: {
-                          'achieved-on': edited_achieved_on,
                           name: edited_name,
-                          amount: edited_amount
+                          amount: edited_amount,
+                          'achieved-on': edited_achieved_on,
+                          'created-at': to_api_timestamp_format(goal.created_at),
+                          'updated-at': assigned_updated_at
                       },
                       relationships: {
                           balance: {
@@ -317,9 +326,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                           self: "#{host}#{request}"
                       },
                       attributes: {
-                          'achieved-on': goal.achieved_on,
                           name: goal.name,
-                          amount: goal.amount
+                          amount: goal.amount,
+                          'achieved-on': goal.achieved_on,
+                          'created-at': to_api_timestamp_format(goal.created_at),
+                          'updated-at': to_api_timestamp_format(goal.updated_at)
                       },
                       relationships: {
                           balance: {
@@ -413,7 +424,6 @@ RSpec.describe Api::V1::GoalsController, type: :request do
 
     context 'with a valid api-token' do
       let (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
-      let(:assigned_id) {json['data']['id']}
       let(:no_next_goal_achieved_on) {nil}
       let(:no_next_goal_name) {'TBD'}
       let(:no_next_goal_amount) {1000}
@@ -432,9 +442,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                       id: goal.id,
                       type: resource_type,
                       attributes: {
-                          'achieved-on': goal.achieved_on,
                           name: goal.name,
-                          amount: goal.amount
+                          amount: goal.amount,
+                          'achieved-on': goal.achieved_on,
+                          'created-at': to_api_timestamp_format(goal.created_at),
+                          'updated-at': to_api_timestamp_format(goal.updated_at)
                       }
                   }
               }.with_indifferent_access
@@ -461,9 +473,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                       id: assigned_id,
                       type: resource_type,
                       attributes: {
-                          'achieved-on': no_next_goal_achieved_on,
                           name: no_next_goal_name,
-                          amount: goal.amount + no_next_goal_amount
+                          amount: goal.amount + no_next_goal_amount,
+                          'achieved-on': no_next_goal_achieved_on,
+                          'created-at': assigned_created_at,
+                          'updated-at': assigned_updated_at
                       }
                   }
               }.with_indifferent_access
@@ -482,16 +496,17 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         end
 
         it 'creates a new goal that is to be defined' do
-
           expected =
               {
                   data: {
                       id: assigned_id,
                       type: resource_type,
                       attributes: {
-                          'achieved-on': no_next_goal_achieved_on,
                           name: no_next_goal_name,
-                          amount: no_next_goal_amount
+                          amount: no_next_goal_amount,
+                          'achieved-on': no_next_goal_achieved_on,
+                          'created-at': assigned_created_at,
+                          'updated-at': assigned_updated_at
                       }
                   }
               }.with_indifferent_access
@@ -544,9 +559,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                       id: goal1.id,
                       type: resource_type,
                       attributes: {
-                          'achieved-on': goal1.achieved_on.to_s,
                           name: goal1.name,
-                          amount: goal1.amount
+                          amount: goal1.amount,
+                          'achieved-on': goal1.achieved_on.to_s,
+                          'created-at': to_api_timestamp_format(goal1.created_at),
+                          'updated-at': to_api_timestamp_format(goal1.updated_at)
                       }
                   }
               }.with_indifferent_access
@@ -575,9 +592,11 @@ RSpec.describe Api::V1::GoalsController, type: :request do
                       id: nil,
                       type: resource_type,
                       attributes: {
-                          'achieved-on': no_previous_goal_achieved_on,
                           name: no_previous_goal_name,
-                          amount: no_previous_goal_amount
+                          amount: no_previous_goal_amount,
+                          'achieved-on': no_previous_goal_achieved_on,
+                          'created-at': assigned_created_at,
+                          'updated-at': assigned_updated_at
                       }
                   }
               }.with_indifferent_access

--- a/spec/resources/api/v1/balance_resource_spec.rb
+++ b/spec/resources/api/v1/balance_resource_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe Api::V1::BalanceResource, type: :resource do
 
   it {is_expected.to have_primary_key :id}
 
-  it {is_expected.to have_attribute :current}
   it {is_expected.to have_attribute :name}
+  it {is_expected.to have_attribute :current}
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
+
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :current}
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
 end

--- a/spec/resources/api/v1/goal_resource_spec.rb
+++ b/spec/resources/api/v1/goal_resource_spec.rb
@@ -7,9 +7,17 @@ RSpec.describe Api::V1::GoalResource, type: :resource do
 
   it {is_expected.to have_primary_key :id}
 
-  it {is_expected.to have_attribute :achieved_on}
   it {is_expected.to have_attribute :name}
   it {is_expected.to have_attribute :amount}
+  it {is_expected.to have_attribute :achieved_on}
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
+
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :amount}
+  it {is_expected.to filter :achieved_on}
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
 
   it {is_expected.to have_one :balance}
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -4,4 +4,20 @@ module RequestHelpers
   def json
     JSON.parse(response.body).with_indifferent_access
   end
+
+  def assigned_id
+    json['data']['id']
+  end
+
+  def assigned_created_at
+    json['data']['attributes']['created-at']
+  end
+
+  def assigned_updated_at
+    json['data']['attributes']['updated-at']
+  end
+
+  def to_api_timestamp_format(timestamp)
+    timestamp.strftime('%FT%T.%LZ')
+  end
 end


### PR DESCRIPTION
Added created_at and updated_at fields to API responses for Balance and Goal resources and updated the associated tests.