### PR TITLE
Added REST API functionality for liking / unliking transactions

### DIFF
--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,2 +1,42 @@
 class Api::V1::TransactionsController < Api::V1::ApiController
+  before_action :set_transaction_and_user, only: [:create_like, :destroy_like]
+
+  def create_like
+    @transaction.liked_by @user
+
+    redirect_to api_v1_vote_path(Vote.last)
+  end
+
+  def destroy_like
+    @transaction.unliked_by @user
+  end
+
+  private
+
+  def set_transaction_and_user
+    transaction_id = params[:id]
+    user_id = params[:user_id]
+
+    begin
+      begin
+        @transaction = Transaction.find(transaction_id)
+      rescue
+        raise JSONAPI::Exceptions::RecordNotFound.new(
+            transaction_id,
+            title: 'Transaction record not found',
+            detail: "The transaction record identified by #{transaction_id} could not be found.")
+      end
+
+      begin
+        @user = User.find(user_id)
+      rescue
+        raise JSONAPI::Exceptions::RecordNotFound.new(
+            user_id,
+            title: 'User record not found',
+            detail: "The user record identified by #{user_id} could not be found.")
+      end
+    rescue => e
+      handle_exceptions(e)
+    end
+  end
 end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -1,13 +1,13 @@
 class Api::V1::TransactionsController < Api::V1::ApiController
-  before_action :set_transaction_and_user, only: [:create_like, :destroy_like]
+  before_action :set_transaction_and_user, only: [:update_vote, :destroy_vote]
 
-  def create_like
+  def update_vote
     @transaction.liked_by @user
 
     redirect_to api_v1_vote_path(Vote.last)
   end
 
-  def destroy_like
+  def destroy_vote
     @transaction.unliked_by @user
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,13 @@ Rails.application.routes.draw do
         end
       end
 
-      jsonapi_resources :transactions
+      jsonapi_resources :transactions do
+        member do
+          get 'like/:user_id', to: 'transactions#create_like'
+          delete 'like/:user_id', to: 'transactions#destroy_like'
+        end
+      end
+
       jsonapi_resources :activities
       jsonapi_resources :users
       jsonapi_resources :votes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,8 +41,8 @@ Rails.application.routes.draw do
 
       jsonapi_resources :transactions do
         member do
-          get 'like/:user_id', to: 'transactions#create_like'
-          delete 'like/:user_id', to: 'transactions#destroy_like'
+          put 'votes/:user_id', to: 'transactions#update_vote'
+          delete 'votes/:user_id', to: 'transactions#destroy_vote'
         end
       end
 

--- a/spec/requests/api/v1/transactions_controller_spec.rb
+++ b/spec/requests/api/v1/transactions_controller_spec.rb
@@ -353,7 +353,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
   end
 
-  describe 'GET api/v1/transactions/:id/like/:user_id' do
+  describe 'PUT api/v1/transactions/:id/votes/:user_id' do
     let! (:transaction) {create(:transaction)}
     let (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
     let (:default_vote_flag) {true}
@@ -365,11 +365,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     context 'with a valid api-token' do
       context 'and a valid transaction id' do
         context 'and a valid user id' do
-          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+          let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
-            get request, headers: {'Api-Token': user.api_token}
+            put request, headers: {'Api-Token': user.api_token}
           end
 
           it 'persists the vote' do
@@ -393,11 +393,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
           expect_status_302_found
         end
         context 'and an invalid user id' do
-          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{invalid_user_id}"}
+          let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{invalid_user_id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
-            get request, headers: {'Api-Token': user.api_token}
+            put request, headers: {'Api-Token': user.api_token}
           end
 
           expect_user_record_not_found_response
@@ -409,11 +409,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
       end
       context 'an an invalid transaction id' do
         context 'and a valid user id' do
-          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{user.id}"}
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/votes/#{user.id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
-            get request, headers: {'Api-Token': user.api_token}
+            put request, headers: {'Api-Token': user.api_token}
           end
 
           expect_transaction_record_not_found_response
@@ -424,11 +424,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         end
 
         context 'and an invalid user id' do
-          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{invalid_user_id}"}
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/votes/#{invalid_user_id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
-            get request, headers: {'Api-Token': user.api_token}
+            put request, headers: {'Api-Token': user.api_token}
           end
 
           expect_transaction_record_not_found_response
@@ -441,11 +441,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
 
     context 'with an invalid api-token' do
-      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
       let! (:record_count_before_request) {Vote.count}
 
       before do
-        get request, headers: {'Api-Token': 'invalid api-token'}
+        put request, headers: {'Api-Token': 'invalid api-token'}
       end
 
       expect_vote_record_count_same
@@ -456,11 +456,11 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
 
     context 'without an api-token' do
-      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
       let! (:record_count_before_request) {Vote.count}
 
       before do
-        get request
+        put request
       end
 
       expect_vote_record_count_same
@@ -471,7 +471,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
   end
 
-  describe 'DELETE api/v1/transactions/:id/like/:user_id' do
+  describe 'DELETE api/v1/transactions/:id/votes/:user_id' do
     let! (:transaction) {create(:transaction)}
     let! (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
     let!(:vote) {
@@ -483,7 +483,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     context 'with a valid api-token' do
       context 'and a valid transaction id' do
         context 'and a valid user id' do
-          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+          let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
@@ -499,7 +499,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
           expect_status_204_no_content
         end
         context 'and an invalid user id' do
-          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{invalid_user_id}"}
+          let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{invalid_user_id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
@@ -515,7 +515,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
       end
       context 'an an invalid transaction id' do
         context 'and a valid user id' do
-          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{user.id}"}
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/votes/#{user.id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
@@ -530,7 +530,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         end
 
         context 'and an invalid user id' do
-          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{invalid_user_id}"}
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/votes/#{invalid_user_id}"}
           let! (:record_count_before_request) {Vote.count}
 
           before do
@@ -547,7 +547,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
 
     context 'with an invalid api-token' do
-      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
       let! (:record_count_before_request) {Vote.count}
 
       before do
@@ -562,7 +562,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
     end
 
     context 'without an api-token' do
-      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let (:request) {"/api/v1/transactions/#{transaction.id}/votes/#{user.id}"}
       let! (:record_count_before_request) {Vote.count}
 
       before do

--- a/spec/requests/api/v1/transactions_controller_spec.rb
+++ b/spec/requests/api/v1/transactions_controller_spec.rb
@@ -1,21 +1,39 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
+def expect_transaction_record_count_same
+  it 'does not change the transaction record count' do
     expect(record_count_before_request).to be == Transaction.count
   end
 end
 
-def expect_record_count_increase
-  it 'increases the record count' do
+def expect_transaction_record_count_increase
+  it 'increases the transaction record count' do
     expect(record_count_before_request).to be < Transaction.count
   end
 end
 
-def expect_record_count_decrease
-  it 'decreases the record count' do
+def expect_transaction_record_count_decrease
+  it 'decreases the transaction record count' do
     expect(record_count_before_request).to be > Transaction.count
+  end
+end
+
+def expect_vote_record_count_same
+  it 'does not change the vote record count' do
+    expect(record_count_before_request).to be == Vote.count
+  end
+end
+
+def expect_vote_record_count_increase
+  it 'increases the vote record count' do
+    expect(record_count_before_request).to be < Vote.count
+  end
+end
+
+def expect_vote_record_count_decrease
+  it 'decreases the vote record count' do
+    expect(record_count_before_request).to be > Vote.count
   end
 end
 
@@ -35,7 +53,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       it 'returns all transactions' do
         expected =
@@ -157,7 +175,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       expect_unauthorized_response
 
@@ -171,7 +189,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       expect_unauthorized_response
 
@@ -191,7 +209,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       it 'returns the transaction associated with the id' do
         expected =
@@ -261,7 +279,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       expect_unauthorized_response
 
@@ -275,7 +293,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       expect_unauthorized_response
 
@@ -301,7 +319,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         expect {Transaction.find(transaction.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_transaction_record_count_decrease
 
       expect_status_204_no_content
     end
@@ -313,7 +331,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
 
       expect_unauthorized_response
 
@@ -327,7 +345,231 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_transaction_record_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v1/transactions/:id/like/:user_id' do
+    let! (:transaction) {create(:transaction)}
+    let (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
+    let (:default_vote_flag) {true}
+    let (:default_vote_scope) {nil}
+    let (:default_vote_weight) {1}
+    let (:invalid_transaction_id) {-1}
+    let (:invalid_user_id) {-1}
+
+    context 'with a valid api-token' do
+      context 'and a valid transaction id' do
+        context 'and a valid user id' do
+          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            get request, headers: {'Api-Token': user.api_token}
+          end
+
+          it 'persists the vote' do
+            created_vote = Vote.find_by(votable_id: transaction.id, voter_id: user.id)
+
+            expect(created_vote.votable_type).to eq(transaction.class.name)
+            expect(created_vote.votable_id).to eq(transaction.id)
+            expect(created_vote.voter_type).to eq(user.class.name)
+            expect(created_vote.voter_id).to eq(user.id)
+            expect(created_vote.vote_flag).to eq(default_vote_flag)
+            expect(created_vote.vote_scope).to eq(default_vote_scope)
+            expect(created_vote.vote_weight).to eq(default_vote_weight)
+          end
+
+          expect_vote_record_count_increase
+
+          it 'redirects to the created vote path' do
+            expect(response).to redirect_to api_v1_vote_path(Vote.last)
+          end
+
+          expect_status_302_found
+        end
+        context 'and an invalid user id' do
+          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{invalid_user_id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            get request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_user_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+      end
+      context 'an an invalid transaction id' do
+        context 'and a valid user id' do
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{user.id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            get request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_transaction_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+
+        context 'and an invalid user id' do
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{invalid_user_id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            get request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_transaction_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let! (:record_count_before_request) {Vote.count}
+
+      before do
+        get request, headers: {'Api-Token': 'invalid api-token'}
+      end
+
+      expect_vote_record_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let! (:record_count_before_request) {Vote.count}
+
+      before do
+        get request
+      end
+
+      expect_vote_record_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'DELETE api/v1/transactions/:id/like/:user_id' do
+    let! (:transaction) {create(:transaction)}
+    let! (:user) {create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA')}
+    let!(:vote) {
+      create(:vote, votable_type: 'Transaction', votable_id: transaction.id, voter_type: 'User', voter_id: user.id)
+    }
+    let (:invalid_transaction_id) {-1}
+    let (:invalid_user_id) {-1}
+
+    context 'with a valid api-token' do
+      context 'and a valid transaction id' do
+        context 'and a valid user id' do
+          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            delete request, headers: {'Api-Token': user.api_token}
+          end
+
+          it "deletes the vote associated with the transaction and user id's" do
+            expect {Vote.find(vote.id)}.to raise_error(ActiveRecord::RecordNotFound)
+          end
+
+          expect_vote_record_count_decrease
+
+          expect_status_204_no_content
+        end
+        context 'and an invalid user id' do
+          let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{invalid_user_id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            delete request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_user_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+      end
+      context 'an an invalid transaction id' do
+        context 'and a valid user id' do
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{user.id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            delete request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_transaction_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+
+        context 'and an invalid user id' do
+          let (:request) {"/api/v1/transactions/#{invalid_transaction_id}/like/#{invalid_user_id}"}
+          let! (:record_count_before_request) {Vote.count}
+
+          before do
+            delete request, headers: {'Api-Token': user.api_token}
+          end
+
+          expect_transaction_record_not_found_response
+
+          expect_vote_record_count_same
+
+          expect_status_404_not_found
+        end
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let! (:record_count_before_request) {Vote.count}
+
+      before do
+        delete request, headers: {'Api-Token': 'invalid api-token'}
+      end
+
+      expect_vote_record_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let (:request) {"/api/v1/transactions/#{transaction.id}/like/#{user.id}"}
+      let! (:record_count_before_request) {Vote.count}
+
+      before do
+        delete request
+      end
+
+      expect_vote_record_count_same
 
       expect_unauthorized_response
 

--- a/spec/shared/api/v1/shared_expectations.rb
+++ b/spec/shared/api/v1/shared_expectations.rb
@@ -13,6 +13,40 @@ def expect_unauthorized_response
   end
 end
 
+def expect_user_record_not_found_response
+  it 'returns a user not found message' do
+    expected = {
+        errors: [
+            {
+                title: 'User record not found',
+                detail: 'The user record identified by -1 could not be found.',
+                code: '404',
+                status: '404'
+            }
+        ]
+    }.with_indifferent_access
+
+    expect(json).to match(expected)
+  end
+end
+
+def expect_transaction_record_not_found_response
+  it 'returns a transaction not found message' do
+    expected = {
+        errors: [
+            {
+                title: 'Transaction record not found',
+                detail: 'The transaction record identified by -1 could not be found.',
+                code: '404',
+                status: '404'
+            }
+        ]
+    }.with_indifferent_access
+
+    expect(json).to match(expected)
+  end
+end
+
 def expect_status_200_ok
   it 'returns a 200 (ok) status code' do
     expect(response).to have_http_status(200)
@@ -31,8 +65,20 @@ def expect_status_204_no_content
   end
 end
 
+def expect_status_302_found
+  it 'returns a 302 (found) status code' do
+    expect(response).to have_http_status(302)
+  end
+end
+
 def expect_status_401_unauthorized
   it 'returns a 401 (unauthorized) status code' do
     expect(response).to have_http_status(401)
+  end
+end
+
+def expect_status_404_not_found
+  it 'returns a 404 (not found) status code' do
+    expect(response).to have_http_status(404)
   end
 end

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -17,10 +17,6 @@ module RequestHelpers
     json['data']['attributes']['updated-at']
   end
 
-  def assigned_image_updated_at
-    json['data']['attributes']['image_updated_at']
-  end
-
   def to_api_timestamp_format(timestamp)
     timestamp.strftime('%FT%T.%LZ')
   end


### PR DESCRIPTION
It is now possible to like and unlike Kudo-transactions by using following request (PUT and DELETE): /transaction/:id/votes/:user_id

See documentation: https://documenter.getpostman.com/view/2855361/kudo-o-matic/713dvx9