### PR TITLE
Refactored API tests

### DIFF
--- a/spec/requests/api/v1/activities_controller_spec.rb
+++ b/spec/requests/api/v1/activities_controller_spec.rb
@@ -1,24 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
-    expect(record_count_before_request).to be == Activity.count
-  end
-end
-
-def expect_record_count_increase
-  it 'increases the record count' do
-    expect(record_count_before_request).to be < Activity.count
-  end
-end
-
-def expect_record_count_decrease
-  it 'decreases the record count' do
-    expect(record_count_before_request).to be > Activity.count
-  end
-end
-
 RSpec.describe Api::V1::ActivitiesController, type: :request do
   include RequestHelpers
 
@@ -35,7 +17,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       it 'returns all activities' do
         expected =
@@ -97,7 +79,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -109,7 +91,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -129,7 +111,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       it 'returns the activity associated with the id' do
         expected =
@@ -168,7 +150,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -180,7 +162,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -220,7 +202,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         expect(new_activity.suggested_amount).to eq(activity.suggested_amount)
       end
 
-      expect_record_count_increase
+      expect_activity_count_increase
 
       it 'returns the created activity' do
         expected =
@@ -272,7 +254,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -296,7 +278,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -340,7 +322,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
           expect(updated_activity.suggested_amount).to eq(edited_suggested_amount)
         end
 
-        expect_record_count_same
+        expect_activity_count_same
 
         it 'returns the updated activity associated with the id with updated values' do
           expected =
@@ -388,7 +370,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
           expect(updated_activity.suggested_amount).to eq(activity.suggested_amount)
         end
 
-        expect_record_count_same
+        expect_activity_count_same
 
         it 'returns the updated activity associated with the id without updated values' do
           expected =
@@ -442,7 +424,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -467,7 +449,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -491,7 +473,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         expect {Activity.find(activity.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_activity_count_decrease
 
       expect_status_204_no_content
     end
@@ -501,7 +483,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 
@@ -513,7 +495,7 @@ RSpec.describe Api::V1::ActivitiesController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_activity_count_same
 
       expect_unauthorized_response
 

--- a/spec/requests/api/v1/balances_controller_spec.rb
+++ b/spec/requests/api/v1/balances_controller_spec.rb
@@ -1,24 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
-    expect(record_count_before_request).to be == Balance.count
-  end
-end
-
-def expect_record_count_increase
-  it 'increases the record count' do
-    expect(record_count_before_request).to be < Balance.count
-  end
-end
-
-def expect_record_count_decrease
-  it 'decreases the record count' do
-    expect(record_count_before_request).to be > Balance.count
-  end
-end
-
 RSpec.describe Api::V1::BalancesController, type: :request do
   include RequestHelpers
 
@@ -35,7 +17,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       it 'returns all balances' do
         expected =
@@ -99,7 +81,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -111,7 +93,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -131,7 +113,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       it 'returns the balance associated with the id' do
         expected =
@@ -171,7 +153,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -183,7 +165,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -212,7 +194,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         expect(new_balance.current).to eq(balance.current)
       end
 
-      expect_record_count_increase
+      expect_balance_count_increase
 
       it 'returns the created balance' do
         expected =
@@ -254,7 +236,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
              params: {data: {type: 'balances', attributes: {name: balance.name, current: balance.current}}}.to_json
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -268,7 +250,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
              params: {data: {type: 'balances', attributes: {name: balance.name, current: balance.current}}}.to_json
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -312,7 +294,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
           expect(updated_balance.current).to eq(edited_current)
         end
 
-        expect_record_count_same
+        expect_balance_count_same
 
         it 'returns the updated balance associated with the id with updated values' do
           expected =
@@ -361,7 +343,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
           expect(updated_balance.current).to eq(balance.current)
         end
 
-        expect_record_count_same
+        expect_balance_count_same
 
         it 'returns the updated balance associated with the id without updated values' do
           expected =
@@ -416,7 +398,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -441,7 +423,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -465,7 +447,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         expect {Balance.find(balance.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_balance_count_decrease
 
       expect_status_204_no_content
     end
@@ -475,7 +457,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -487,7 +469,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -507,7 +489,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       it 'redirects to the current balance path' do
         expect(response).to redirect_to api_v1_balance_path(balance)
@@ -521,7 +503,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 
@@ -533,7 +515,7 @@ RSpec.describe Api::V1::BalancesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_balance_count_same
 
       expect_unauthorized_response
 

--- a/spec/requests/api/v1/goals_controller_spec.rb
+++ b/spec/requests/api/v1/goals_controller_spec.rb
@@ -1,24 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
-    expect(record_count_before_request).to be == Goal.count
-  end
-end
-
-def expect_record_count_increase
-  it 'increases the record count' do
-    expect(record_count_before_request).to be < Goal.count
-  end
-end
-
-def expect_record_count_decrease
-  it 'decreases the record count' do
-    expect(record_count_before_request).to be > Goal.count
-  end
-end
-
 RSpec.describe Api::V1::GoalsController, type: :request do
   include RequestHelpers
 
@@ -35,7 +17,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       it 'returns all goals' do
         expected =
@@ -99,7 +81,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -111,7 +93,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -131,7 +113,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       it 'returns the goal associated with the id' do
         expected =
@@ -171,7 +153,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -183,7 +165,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -225,7 +207,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         expect(new_goal.amount).to eq(goal.amount)
       end
 
-      expect_record_count_increase
+      expect_goal_count_increase
 
       it 'returns the created goal' do
         expected =
@@ -279,7 +261,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -305,7 +287,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -352,7 +334,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           expect(updated_goal.amount).to eq(edited_amount)
         end
 
-        expect_record_count_same
+        expect_goal_count_same
 
         it 'returns the updated goal associated with the id with updated values' do
           expected =
@@ -410,7 +392,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           expect(updated_goal.amount).to eq(goal.amount)
         end
 
-        expect_record_count_same
+        expect_goal_count_same
 
         it 'returns the updated vote associated with the id without updated values' do
           expected =
@@ -465,7 +447,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -490,7 +472,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -514,7 +496,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         expect {Goal.find(goal.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_goal_count_decrease
 
       expect_status_204_no_content
     end
@@ -524,7 +506,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -536,7 +518,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -558,7 +540,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           get request, headers: {'Api-Token': user.api_token}
         end
 
-        expect_record_count_same
+        expect_goal_count_same
 
         it 'redirects to the next goal path' do
           expect(response).to redirect_to api_v1_goal_path(goal)
@@ -575,7 +557,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           get request, headers: {'Api-Token': user.api_token}
         end
 
-        expect_record_count_increase
+        expect_goal_count_increase
 
         it 'redirects to the next goal path' do
           expect(response).to redirect_to api_v1_goal_path(Goal.last)
@@ -591,7 +573,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           get request, headers: {'Api-Token': user.api_token}
         end
 
-        expect_record_count_increase
+        expect_goal_count_increase
 
         it 'redirects to the next goal path' do
           expect(response).to redirect_to api_v1_goal_path(Goal.last)
@@ -608,7 +590,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -622,7 +604,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -644,7 +626,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           get request, headers: {'Api-Token': user.api_token}
         end
 
-        expect_record_count_same
+        expect_goal_count_same
 
         it 'redirects to the previous goal path' do
           expect(response).to redirect_to api_v1_goal_path(goal)
@@ -660,7 +642,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
           get request, headers: {'Api-Token': user.api_token}
         end
 
-        expect_record_count_same
+        expect_goal_count_same
 
         expect_previous_goal_record_not_found_response
 
@@ -675,7 +657,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 
@@ -689,7 +671,7 @@ RSpec.describe Api::V1::GoalsController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_goal_count_same
 
       expect_unauthorized_response
 

--- a/spec/requests/api/v1/transactions_controller_spec.rb
+++ b/spec/requests/api/v1/transactions_controller_spec.rb
@@ -1,42 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_transaction_record_count_same
-  it 'does not change the transaction record count' do
-    expect(record_count_before_request).to be == Transaction.count
-  end
-end
-
-def expect_transaction_record_count_increase
-  it 'increases the transaction record count' do
-    expect(record_count_before_request).to be < Transaction.count
-  end
-end
-
-def expect_transaction_record_count_decrease
-  it 'decreases the transaction record count' do
-    expect(record_count_before_request).to be > Transaction.count
-  end
-end
-
-def expect_vote_record_count_same
-  it 'does not change the vote record count' do
-    expect(record_count_before_request).to be == Vote.count
-  end
-end
-
-def expect_vote_record_count_increase
-  it 'increases the vote record count' do
-    expect(record_count_before_request).to be < Vote.count
-  end
-end
-
-def expect_vote_record_count_decrease
-  it 'decreases the vote record count' do
-    expect(record_count_before_request).to be > Vote.count
-  end
-end
-
 RSpec.describe Api::V1::TransactionsController, type: :request do
   include RequestHelpers
 
@@ -53,7 +17,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       it 'returns all transactions' do
         expected =
@@ -175,7 +139,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -187,7 +151,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -207,7 +171,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       it 'returns the transaction associated with the id' do
         expected =
@@ -276,7 +240,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -288,7 +252,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         get request
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -364,7 +328,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
           expect(new_transaction.amount).to eq(transaction.amount)
         end
 
-        expect_transaction_record_count_increase
+        expect_transaction_count_increase
 
         it 'returns the created transaction' do
           expected =
@@ -470,7 +434,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
              }.to_json
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -519,7 +483,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
              }.to_json
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -588,7 +552,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
           expect(updated_transaction.amount).to eq(edited_amount)
         end
 
-        expect_transaction_record_count_same
+        expect_transaction_count_same
 
         it 'returns the updated transaction associated with the id with updated values' do
           expected =
@@ -697,7 +661,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
           expect(updated_transaction.amount).to eq(transaction.amount)
         end
 
-        expect_transaction_record_count_same
+        expect_transaction_count_same
 
         it 'returns the updated transaction associated with the id without updated values' do
           expected =
@@ -801,7 +765,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
               }.to_json
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -848,7 +812,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
               }.to_json
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -872,7 +836,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         expect {Transaction.find(transaction.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_transaction_record_count_decrease
+      expect_transaction_count_decrease
 
       expect_status_204_no_content
     end
@@ -882,7 +846,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -894,7 +858,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request
       end
 
-      expect_transaction_record_count_same
+      expect_transaction_count_same
 
       expect_unauthorized_response
 
@@ -933,7 +897,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
             expect(created_vote.vote_weight).to eq(default_vote_weight)
           end
 
-          expect_vote_record_count_increase
+          expect_vote_count_increase
 
           it 'redirects to the created vote path' do
             expect(response).to redirect_to api_v1_vote_path(Vote.last)
@@ -951,7 +915,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_user_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -967,7 +931,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_transaction_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -982,7 +946,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_transaction_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -997,7 +961,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         put request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_vote_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -1012,7 +976,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         put request
       end
 
-      expect_vote_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -1043,7 +1007,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
             expect {Vote.find(vote.id)}.to raise_error(ActiveRecord::RecordNotFound)
           end
 
-          expect_vote_record_count_decrease
+          expect_vote_count_decrease
 
           expect_status_204_no_content
         end
@@ -1057,7 +1021,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_user_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -1073,7 +1037,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_transaction_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -1088,7 +1052,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
 
           expect_transaction_record_not_found_response
 
-          expect_vote_record_count_same
+          expect_vote_count_same
 
           expect_status_404_not_found
         end
@@ -1103,7 +1067,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_vote_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -1118,7 +1082,7 @@ RSpec.describe Api::V1::TransactionsController, type: :request do
         delete request
       end
 
-      expect_vote_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,24 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
-    expect(record_count_before_request).to be == User.count
-  end
-end
-
-def expect_record_count_increase
-  it 'increases the record count' do
-    expect(record_count_before_request).to be < User.count
-  end
-end
-
-def expect_record_count_decrease
-  it 'decreases the record count' do
-    expect(record_count_before_request).to be > User.count
-  end
-end
-
 RSpec.describe Api::V1::UsersController, type: :request do
   include RequestHelpers
 
@@ -33,7 +15,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request, headers: {'Api-Token': user1.api_token}
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       it 'returns all users' do
         expected =
@@ -123,7 +105,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -135,7 +117,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -153,7 +135,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       it 'returns the user associated with the id' do
         expected =
@@ -206,7 +188,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -218,7 +200,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -260,7 +242,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         expect(new_user.admin).to eq(user.admin)
       end
 
-      expect_record_count_increase
+      expect_user_count_increase
 
       it 'returns the created user' do
         expected =
@@ -328,7 +310,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -354,7 +336,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -402,7 +384,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
           expect(updated_user.admin).to eq(edited_admin)
         end
 
-        expect_record_count_same
+        expect_user_count_same
 
         it 'returns the updated user associated with the id with updated values' do
           expected =
@@ -466,7 +448,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
           expect(updated_user.admin).to eq(user.admin)
         end
 
-        expect_record_count_same
+        expect_user_count_same
 
         it 'returns the updated user associated with the id without updated values' do
           expected =
@@ -536,7 +518,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -563,7 +545,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -586,7 +568,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         expect {User.find(user.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_user_count_decrease
 
       expect_status_204_no_content
     end
@@ -596,7 +578,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 
@@ -608,7 +590,7 @@ RSpec.describe Api::V1::UsersController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_user_count_same
 
       expect_unauthorized_response
 

--- a/spec/requests/api/v1/votes_controller_spec.rb
+++ b/spec/requests/api/v1/votes_controller_spec.rb
@@ -1,24 +1,6 @@
 require 'rails_helper'
 require 'shared/api/v1/shared_expectations'
 
-def expect_record_count_same
-  it 'does not change the record count' do
-    expect(record_count_before_request).to be == Vote.count
-  end
-end
-
-def expect_record_count_increase
-  it 'increases the record count' do
-    expect(record_count_before_request).to be < Vote.count
-  end
-end
-
-def expect_record_count_decrease
-  it 'decreases the record count' do
-    expect(record_count_before_request).to be > Vote.count
-  end
-end
-
 RSpec.describe Api::V1::VotesController, type: :request do
   include RequestHelpers
 
@@ -35,7 +17,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       it 'returns all votes' do
         expected =
@@ -119,7 +101,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -131,7 +113,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -151,7 +133,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request, headers: {'Api-Token': user.api_token}
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       it 'returns the vote associated with the id' do
         expected =
@@ -201,7 +183,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -213,7 +195,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         get request
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -263,7 +245,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         expect(new_vote.vote_weight).to eq(vote.vote_weight)
       end
 
-      expect_record_count_increase
+      expect_vote_count_increase
 
       it 'returns the created vote' do
         expected =
@@ -331,7 +313,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -361,7 +343,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
              }.to_json
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -420,7 +402,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
           expect(updated_vote.vote_weight).to eq(edited_vote_weight)
         end
 
-        expect_record_count_same
+        expect_vote_count_same
 
         it 'returns the updated vote associated with the id with updated values' do
           expected =
@@ -492,7 +474,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
           expect(updated_vote.vote_weight).to eq(vote.vote_weight)
         end
 
-        expect_record_count_same
+        expect_vote_count_same
 
         it 'returns the updated vote associated with the id without updated values' do
           expected =
@@ -562,7 +544,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -592,7 +574,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
               }.to_json
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -616,7 +598,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         expect {Vote.find(vote.id)}.to raise_error(ActiveRecord::RecordNotFound)
       end
 
-      expect_record_count_decrease
+      expect_vote_count_decrease
 
       expect_status_204_no_content
     end
@@ -626,7 +608,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         delete request, headers: {'Api-Token': 'invalid api-token'}
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 
@@ -638,7 +620,7 @@ RSpec.describe Api::V1::VotesController, type: :request do
         delete request
       end
 
-      expect_record_count_same
+      expect_vote_count_same
 
       expect_unauthorized_response
 

--- a/spec/resources/api/v1/activity_resource_spec.rb
+++ b/spec/resources/api/v1/activity_resource_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe Api::V1::ActivityResource, type: :resource do
   it {is_expected.to have_attribute :name}
   it {is_expected.to have_attribute :suggested_amount}
 
-  it {is_expected.to filter :name}
-  it {is_expected.to filter :suggested_amount}
   it {is_expected.to filter :created_at}
   it {is_expected.to filter :updated_at}
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :suggested_amount}
 
   it {is_expected.to have_many :transactions}
 end

--- a/spec/resources/api/v1/balance_resource_spec.rb
+++ b/spec/resources/api/v1/balance_resource_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Api::V1::BalanceResource, type: :resource do
   it {is_expected.to have_attribute :current}
   it {is_expected.to have_attribute :amount}
 
-  it {is_expected.to filter :name}
-  it {is_expected.to filter :current}
   it {is_expected.to filter :created_at}
   it {is_expected.to filter :updated_at}
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :current}
+  it {is_expected.to filter :amount}
 
   it {is_expected.to have_many :transactions}
 end

--- a/spec/resources/api/v1/goal_resource_spec.rb
+++ b/spec/resources/api/v1/goal_resource_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Api::V1::GoalResource, type: :resource do
   it {is_expected.to have_attribute :amount}
   it {is_expected.to have_attribute :achieved_on}
 
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
   it {is_expected.to filter :name}
   it {is_expected.to filter :amount}
   it {is_expected.to filter :achieved_on}
-  it {is_expected.to filter :created_at}
-  it {is_expected.to filter :updated_at}
 
   it {is_expected.to have_one :balance}
 end

--- a/spec/resources/api/v1/transaction_resource_spec.rb
+++ b/spec/resources/api/v1/transaction_resource_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Api::V1::TransactionResource, type: :resource do
   it {is_expected.to have_attribute :image_url_thumb}
   it {is_expected.to have_attribute :likes_amount}
 
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
   it {is_expected.to filter :amount}
   it {is_expected.to filter :image_url_original}
   it {is_expected.to filter :image_url_thumb}
@@ -25,8 +27,6 @@ RSpec.describe Api::V1::TransactionResource, type: :resource do
   it {is_expected.to filter :image_content_type}
   it {is_expected.to filter :image_file_size}
   it {is_expected.to filter :image_updated_at}
-  it {is_expected.to filter :created_at}
-  it {is_expected.to filter :updated_at}
   it {is_expected.to filter :likes_amount}
 
   it {is_expected.to have_one :balance}

--- a/spec/resources/api/v1/vote_resource_spec.rb
+++ b/spec/resources/api/v1/vote_resource_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Api::V1::VoteResource, type: :resource do
 
   it {is_expected.to have_primary_key :id}
 
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
   it {is_expected.to have_attribute :votable_type}
   it {is_expected.to have_attribute :votable_id}
   it {is_expected.to have_attribute :voter_type}
@@ -15,6 +17,8 @@ RSpec.describe Api::V1::VoteResource, type: :resource do
   it {is_expected.to have_attribute :vote_scope}
   it {is_expected.to have_attribute :vote_weight}
 
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
   it {is_expected.to filter :votable_type}
   it {is_expected.to filter :votable_id}
   it {is_expected.to filter :voter_type}

--- a/spec/shared/api/v1/shared_expectations.rb
+++ b/spec/shared/api/v1/shared_expectations.rb
@@ -1,3 +1,5 @@
+# expect JSON respones
+
 def expect_unauthorized_response
   it 'returns an unauthorized message' do
     expected = {
@@ -65,6 +67,118 @@ def expect_transaction_record_not_found_response
     expect(json).to match(expected)
   end
 end
+
+# expect record counts
+
+def expect_activity_count_same
+  it 'does not change the activity record count' do
+    expect(record_count_before_request).to be == Activity.count
+  end
+end
+
+def expect_activity_count_increase
+  it 'increases the activity record count' do
+    expect(record_count_before_request).to be < Activity.count
+  end
+end
+
+def expect_activity_count_decrease
+  it 'decreases the activity record count' do
+    expect(record_count_before_request).to be > Activity.count
+  end
+end
+
+def expect_balance_count_same
+  it 'does not change the balance record count' do
+    expect(record_count_before_request).to be == Balance.count
+  end
+end
+
+def expect_balance_count_increase
+  it 'increases the balance record count' do
+    expect(record_count_before_request).to be < Balance.count
+  end
+end
+
+def expect_balance_count_decrease
+  it 'decreases the balance record count' do
+    expect(record_count_before_request).to be > Balance.count
+  end
+end
+
+def expect_goal_count_same
+  it 'does not change the goal record count' do
+    expect(record_count_before_request).to be == Goal.count
+  end
+end
+
+def expect_goal_count_increase
+  it 'increases the goal record count' do
+    expect(record_count_before_request).to be < Goal.count
+  end
+end
+
+def expect_goal_count_decrease
+  it 'decreases the goal record count' do
+    expect(record_count_before_request).to be > Goal.count
+  end
+end
+
+def expect_transaction_count_same
+  it 'does not change the transaction record count' do
+    expect(record_count_before_request).to be == Transaction.count
+  end
+end
+
+def expect_transaction_count_increase
+  it 'increases the transaction record count' do
+    expect(record_count_before_request).to be < Transaction.count
+  end
+end
+
+def expect_transaction_count_decrease
+  it 'decreases the transaction record count' do
+    expect(record_count_before_request).to be > Transaction.count
+  end
+end
+
+def expect_user_count_same
+  it 'does not change the user record count' do
+    expect(record_count_before_request).to be == User.count
+  end
+end
+
+def expect_user_count_increase
+  it 'increases the user record count' do
+    expect(record_count_before_request).to be < User.count
+  end
+end
+
+def expect_user_count_decrease
+  it 'decreases the user record count' do
+    expect(record_count_before_request).to be > User.count
+  end
+end
+
+def expect_vote_count_same
+  it 'does not change the vote record count' do
+    expect(record_count_before_request).to be == Vote.count
+  end
+end
+
+def expect_vote_count_increase
+  it 'increases the vote record count' do
+    expect(record_count_before_request).to be < Vote.count
+  end
+end
+
+def expect_vote_count_decrease
+  it 'decreases the vote record count' do
+    expect(record_count_before_request).to be > Vote.count
+  end
+end
+
+# expect HTTP status codes
 
 def expect_status_200_ok
   it 'returns a 200 (ok) status code' do


### PR DESCRIPTION
Moved the record_count expectations to the shared_expectations file and fixed the order of the API resource expectations.