### PR TITLE
Added pagination functionality to the REST API Transaction resource

### DIFF
--- a/app/resources/api/v1/transaction_resource.rb
+++ b/app/resources/api/v1/transaction_resource.rb
@@ -6,6 +6,7 @@ class Api::V1::TransactionResource < Api::V1::BaseResource
   has_one :activity
   has_one :balance
   has_many :votes
+  paginator :offset
 
   def image_url_original
     # return nil if the transaction has no original image


### PR DESCRIPTION
It is now possible to paginate transactions using the limit and offset params on the GET /transactions request.

The limit specifies the number of transactions that are being returned, and the offset specifies how many transactions to skip from the start.

See documentation: https://documenter.getpostman.com/view/2855361/kudo-o-matic/713dvx9