### PR TITLE
 Implemented deactivation and reactivation of users (replaced removal)

### DIFF
--- a/app/assets/stylesheets/components/_message.scss
+++ b/app/assets/stylesheets/components/_message.scss
@@ -34,11 +34,18 @@
   color: $text-primary;
   text-align: center;
   display: flex;
-  margin-bottom: $margin-secondary;
 
   .hide-message & {
     display: none;
   }
+}
+
+.margin-top {
+  margin-top: $margin-secondary;
+}
+
+.margin-bottom {
+  margin-bottom: $margin-secondary;
 }
 
 .error-message {

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 module Admin
   class UsersController < Admin::ApplicationController
-    before_action :set_user, only: [:update, :destroy]
+    before_action :set_user, only: [:update, :deactivate, :reactivate]
 
     # To customize the behavior of this controller,
     # simply overwrite any of the RESTful actions. For example:
@@ -28,14 +28,19 @@ module Admin
       end
     end
 
-    def destroy
+    def deactivate
       begin
-        @user.destroy
+        @user.deactivate
         redirect_to admin_users_path
       rescue Exception => e
         flash[:error] = e.message
         redirect_back(fallback_location: admin_users_path)
       end
+    end
+
+    def reactivate
+      @user.reactivate
+      redirect_back(fallback_location: admin_users_path)
     end
 
     private

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,14 +1,14 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
-      @user = User.from_omniauth(request.env["omniauth.auth"])
+    @user = User.from_omniauth(request.env["omniauth.auth"])
 
-      if @user.persisted?
-        flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Google"
-        sign_in_and_redirect @user, :event => :authentication
-      else
-        session["devise.google_data"] = request.env["omniauth.auth"]
-        redirect_to new_user_registration_url
-
-      end
+    if @user.persisted? && !@user.deactivated?
+      sign_in_and_redirect @user, event: :authentication
+    elsif @user.deactivated?
+      flash[:notice] = 'Your account is deactivated'
+      redirect_back(fallback_location: new_user_session_path)
+    else
+      redirect_back(fallback_location: new_user_session_path)
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def autocomplete_search
-    @users = User.order(:name).where("lower(name) like ?", "#{params[:term]}%".downcase)
+    @users = User.order(:name).where("lower(name) like ?", "#{params[:term]}%".downcase).where(deactivated_at: nil)
     render json: @users.map(&:name)
   end
 end

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -8,16 +8,18 @@ class UserDashboard < Administrate::BaseDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    sent_transactions: Field::HasMany.with_options(class_name: "Transaction"),
-    received_transactions: Field::HasMany.with_options(class_name: "Transaction"),
-    id: Field::Number,
-    name: Field::String,
-    slack_name: Field::String,
-    admin: Field::Boolean,
-    mail_notifications: Field::Boolean,
-    email: Field::String,
-    created_at: Field::DateTime,
-    updated_at: Field::DateTime,
+      sent_transactions: Field::HasMany.with_options(class_name: "Transaction"),
+      received_transactions: Field::HasMany.with_options(class_name: "Transaction"),
+      id: Field::Number,
+      name: Field::String,
+      slack_name: Field::String,
+      admin: Field::Boolean,
+      mail_notifications: Field::Boolean,
+      email: Field::String,
+      api_token: Field::String,
+      deactivated_at: Field::DateTime,
+      created_at: Field::DateTime,
+      updated_at: Field::DateTime,
   }
 
   # COLLECTION_ATTRIBUTES
@@ -26,38 +28,42 @@ class UserDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
-    :id,
-    :name,
-    :slack_name,
-    :admin,
-    :mail_notifications,
-    :sent_transactions,
-    :received_transactions,
+      :id,
+      :name,
+      :slack_name,
+      :admin,
+      :mail_notifications,
+      :sent_transactions,
+      :received_transactions,
+      :deactivated_at,
   ]
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = [
-    :id,
-    :name,
-    :slack_name,
-    :admin,
-    :mail_notifications,
-    :created_at,
-    :updated_at,
-    :sent_transactions,
-    :received_transactions,
+      :id,
+      :name,
+      :slack_name,
+      :api_token,
+      :admin,
+      :mail_notifications,
+      :created_at,
+      :updated_at,
+      :deactivated_at,
+      :sent_transactions,
+      :received_transactions
   ]
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :name,
-    :email,
-    :slack_name,
-    :admin,
-    :mail_notifications,
+      :name,
+      :email,
+      :slack_name,
+      :api_token,
+      :admin,
+      :mail_notifications
   ]
 
   # Overwrite this method to customize how users are displayed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ActiveRecord::Base
   after_update :ensure_an_admin_remains
-  after_destroy :ensure_an_admin_remains
 
   acts_as_voter
   # Include default devise modules. Others available are:
@@ -47,10 +46,28 @@ class User < ActiveRecord::Base
     avatar_url || '/no-picture-icon.jpg'
   end
 
+  def deactivate
+    update_attribute(:deactivated_at, DateTime.now)
+    ensure_an_admin_remains
+  end
+
+  def reactivate
+    update_attribute(:deactivated_at, nil)
+  end
+
+  def deactivated?
+    !deactivated_at.nil?
+  end
+
+  # overridden Devise method that checks the soft delete timestamp on authentication
+  def active_for_authentication?
+    super && !deactivated_at
+  end
+
   private
 
   def ensure_an_admin_remains
-    if User.where(admin: true).count < 1
+    if User.where(admin: true, deactivated_at: nil).count < 1
       raise "Last administrator can't be removed from the system"
     end
   end

--- a/app/views/admin/users/_collection.html.haml
+++ b/app/views/admin/users/_collection.html.haml
@@ -1,0 +1,26 @@
+%table.collection-data{'aria-labelledby': 'page-title'}
+  %thead
+    %tr
+      - collection_presenter.attribute_types.each do |attr_name, attr_type|
+        %th{class: "cell-label cell-label--#{attr_type.html_class} cell-label--#{collection_presenter.ordered_html_class(attr_name)}", scope: 'col'}
+          = link_to(sanitized_params.merge(collection_presenter.order_params_for(attr_name))) do
+            = t("helpers.label.#{resource_name}.#{attr_name}", default: attr_name.to_s,).titleize
+            - if collection_presenter.ordered_by?(attr_name)
+              %span{class: "cell-label__sort-indicator cell-label__sort-indicator--#{collection_presenter.ordered_html_class(attr_name)}"}
+                = svg_tag('administrate/sort_arrow.svg', 'sort_arrow', width: '13', height: '13')
+      %th{colspan: '2', scope: 'col'}
+  %tbody
+    - resources.each do |resource|
+      %tr.table__row{'data-url': "#{polymorphic_path([namespace, resource])}", role: 'link', tabindex: '0'}
+        - collection_presenter.attributes_for(resource).each do |attribute|
+          %td{class: "cell-data cell-data--#{attribute.html_class}"}
+            = render_field attribute
+        %td= link_to(t('administrate.actions.edit'), [:edit, namespace, resource], class: 'action-edit',)
+        %td
+          - if resource.class == User
+            - if resource.deactivated?
+              = link_to(t('administrate.actions.reactivate'), reactivate_admin_user_path(resource), class: 'table__action', method: :patch, data: {confirm: t('administrate.actions.confirm')})
+            - else
+              = link_to(t('administrate.actions.deactivate'), deactivate_admin_user_path(resource), class: 'table__action--destroy', method: :patch, data: {confirm: t('administrate.actions.confirm')})
+          - else
+            = link_to(t('administrate.actions.destroy'), [namespace, resource], class: "table__action--destroy", method: :delete, data: {confirm: t('administrate.actions.confirm')})

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,0 +1,16 @@
+%body
+  - content_for(:title) do
+    = display_resource_name(page.resource_name)
+  - content_for(:search) do
+    %form.search
+      %span.search__icon
+        = svg_tag 'administrate/search.svg', 'search', width: 16, height: 16
+      %input.search__input{'aria-label': 'Search', name: 'search', placeholder: 'Search', type: 'text', value: search_term}/
+      %span.search__hint
+        Press enter to search
+  %header.header
+    %h1#page-title.header__heading= content_for(:title)
+    .header__actions
+      = link_to("New #{page.resource_name.titleize.downcase}", [:new, namespace, page.resource_name], class: 'button')
+  = render 'collection', collection_presenter: page, resources: resources
+  = paginate resources

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -17,8 +17,12 @@
         = image_tag 'logo-without-lizard-black.png'
         %a.btn-google{href:user_google_oauth2_omniauth_authorize_path}
           = 'Log in with Google+'
+        - if notice
+          .message-container.error-message.margin-top
+            %span.message
+              .fa.fa-exclamation-circle
+              #notice= notice
     .sign-in-footer
-      %span
-        *You can only log in with a Google account from Kabisa
+      *You can only log in with a Google account from Kabisa
 
 

--- a/app/views/transactions/_message.html.haml
+++ b/app/views/transactions/_message.html.haml
@@ -1,6 +1,6 @@
 - if @transaction.errors.any?
   .message-container.show-message
-    .error-message
+    .error-message.margin-bottom
       %span.message
         .fa.fa-exclamation-circle
         %ul

--- a/config/locales/administrate.en.yml
+++ b/config/locales/administrate.en.yml
@@ -1,0 +1,5 @@
+en:
+  administrate:
+    actions:
+      deactivate: 'Deactivate'
+      reactivate: 'Reactivate'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,13 @@ Rails.application.routes.draw do
     resources :goals
     resources :transactions
     resources :activities
-    resources :users
+
+    resources :users, except: :destroy do
+      member do
+        patch :deactivate
+        patch :reactivate
+      end
+    end
   end
 
   namespace :api do

--- a/db/migrate/20171011100001_add_deactivated_at_to_users.rb
+++ b/db/migrate/20171011100001_add_deactivated_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170922113448) do
+ActiveRecord::Schema.define(version: 20171011100001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 20170922113448) do
     t.boolean  "admin",                  default: false
     t.boolean "mail_notifications"
     t.string "api_token"
+    t.datetime "deactivated_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree

--- a/spec/controllers/admin/balances_controller_spec.rb
+++ b/spec/controllers/admin/balances_controller_spec.rb
@@ -1,45 +1,57 @@
 require 'rails_helper'
+require 'shared/controllers/admin/shared_expectations'
 
 RSpec.describe Admin::BalancesController, type: :controller do
   let!(:balance) {create(:balance, :current)}
   let!(:user) {create(:user, :admin)}
 
-  def current_balance_count
-    Balance.where(current: true).count
-  end
-
   before do
     sign_in user
-
-    balance.current = false
   end
 
   describe 'PATCH #update' do
     let (:perform_update) {patch :update, params: {id: balance.id, balance: balance.attributes}}
 
-    context 'with at least one other current balance left' do
-      let!(:current_balance) {create(:balance, :current)}
-
-      it 'successfully updates the current balance to a normal balance' do
-        expect {perform_update}.to change {current_balance_count}
+    context 'updating the a current balance to a normal balance' do
+      before do
+        balance.current = false
       end
 
-      it 'redirects back to admin balance path' do
-        perform_update
+      context 'with at least one other current balance left' do
+        let!(:current_balance) {create(:balance, :current)}
+        let! (:record_count_before_request) {Balance.count}
 
-        expect(response).to redirect_to(admin_balance_path)
+        before do
+          perform_update
+        end
+
+        it 'updates the current balance to a normal balance' do
+          expect(Balance.find(balance.id).current).to eq(false)
+        end
+
+        expect_balance_count_same
+
+        it 'redirects back to the admin balance path' do
+          expect(response).to redirect_to(admin_balance_path)
+        end
       end
-    end
 
-    context 'with no other current balances left' do
-      it 'does not update the current balance to a normal balance' do
-        expect {perform_update}.not_to change {current_balance_count}
-      end
+      context 'with no other current balances left' do
+        let! (:record_count_before_request) {Balance.count}
 
-      it 'redirects back to the edit admin balance page ' do
-        perform_update
+        before do
+          perform_update
+        end
 
-        expect(response).to redirect_to(edit_admin_balance_path)
+        it 'does not update the current balance to a normal balance' do
+          expect(Balance.find(balance.id).current).to eq(true)
+        end
+
+        expect_balance_count_same
+
+        it 'redirects back to the edit admin balance path ' do
+          expect(response).to redirect_to(edit_admin_balance_path(balance.id))
+        end
       end
     end
   end
@@ -47,29 +59,42 @@ RSpec.describe Admin::BalancesController, type: :controller do
   describe 'DELETE #destroy' do
     let (:perform_delete) {delete :destroy, params: {id: balance.id}}
 
-    context 'with at least one other current balance left' do
-      let!(:current_balance) {create(:balance, :current)}
+    context 'deleting the last current balance' do
+      context 'with at least one other current balance left' do
+        let!(:current_balance) {create(:balance, :current)}
+        let! (:record_count_before_request) {Balance.count}
 
-      it 'successfully deletes the current balance' do
-        expect {perform_delete}.to change {current_balance_count}
+        before do
+          perform_delete
+        end
+
+        it 'deletes the current balance' do
+          expect {Balance.find(balance.id)}.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        expect_balance_count_decrease
+
+        it 'redirects back to the admin balances path' do
+          expect(response).to redirect_to(admin_balances_path)
+        end
       end
 
-      it 'redirects back to admin balances path' do
-        perform_delete
+      context 'with no other current balances left' do
+        let! (:record_count_before_request) {Balance.count}
 
-        expect(response).to redirect_to(admin_balances_path)
-      end
-    end
+        before do
+          perform_delete
+        end
 
-    context 'with no other current balances left' do
-      it 'does not delete the current balance' do
-        expect {perform_delete}.not_to change {current_balance_count}
-      end
+        it 'does not delete the current balance' do
+          expect(Balance.find(balance.id)).to eq(balance)
+        end
 
-      it 'redirects back to the admin balances path' do
-        perform_delete
+        expect_balance_count_same
 
-        expect(response).to redirect_to(admin_balances_path)
+        it 'redirects back to the admin balances path' do
+          expect(response).to redirect_to(admin_balances_path)
+        end
       end
     end
   end

--- a/spec/resources/api/v1/vote_resource_spec.rb
+++ b/spec/resources/api/v1/vote_resource_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe Api::V1::VoteResource, type: :resource do
   it {is_expected.to have_attribute :vote_scope}
   it {is_expected.to have_attribute :vote_weight}
 
-  it {is_expected.to have_attribute :created_at}
-  it {is_expected.to have_attribute :updated_at}
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
   it {is_expected.to filter :votable_type}
   it {is_expected.to filter :votable_id}
   it {is_expected.to filter :voter_type}

--- a/spec/shared/controllers/admin/shared_expectations.rb
+++ b/spec/shared/controllers/admin/shared_expectations.rb
@@ -1,0 +1,19 @@
+# expect record counts
+
+def expect_balance_count_same
+  it 'does not change the balance record count' do
+    expect(record_count_before_request).to be == Balance.count
+  end
+end
+
+def expect_balance_count_decrease
+  it 'decreases the balance record count' do
+    expect(record_count_before_request).to be > Balance.count
+  end
+end
+
+def expect_user_count_same
+  it 'does not change the user record count' do
+    expect(record_count_before_request).to be == User.count
+  end
+end


### PR DESCRIPTION
Implemented deactivation and reactivation of users by adding the deactivated_at field to the User model. 

Deactivated users can no longer log in and do no longer show up in the autocomplete list when composing a Kudo transaction. 

Updated the administrator dashboard to support this functionality (HAML code is automatically generated and customized).

Added a account deactivated notice to the new user session view.