### PR TITLE
Added the possibility to include base64 images when adding transactions

### DIFF
--- a/app/models/transaction_adder.rb
+++ b/app/models/transaction_adder.rb
@@ -31,6 +31,11 @@ class TransactionAdder
         balance: Balance.current
     )
 
+    unless attributes[:image].nil? || attributes['image-file-type'].nil?
+      file_type = attributes['image-file-type']
+      transaction.update(image: "data:image/#{file_type};base64,#{attributes[:image]}", image_file_name: "image.#{file_type}")
+    end
+
     save_and_check_goal_reached transaction
   end
 


### PR DESCRIPTION
Added the possibility to include base64 encoded images when adding transactions by adding an image and image-file-type to the request body attributes.