### PR TITLE
Added logic to check if it is necessary to attach an image attachment

### DIFF
--- a/app/mailers/summary_mailer.rb
+++ b/app/mailers/summary_mailer.rb
@@ -14,7 +14,10 @@ class SummaryMailer < ApplicationMailer
     @markdown = Redcarpet::Markdown.new(MdEmoji::Render, no_intra_emphasis: true)
 
     attachments.inline['logo.png'] = File.read("#{Rails.root}/app/assets/images/kudo-o-matic-white-mail.png")
-    attachments.inline['no-picture.jpg'] = File.read("#{Rails.root}/public/no-picture-icon.jpg")
+
+    if @transactions.any? {|t| t.sender.avatar_url.blank? || t.receiver.avatar_url.blank?}
+      attachments.inline['no-picture.jpg'] = File.read("#{Rails.root}/public/no-picture-icon.jpg")
+    end
 
     mail(to: user.email, subject: 'Weekly ₭udo summary!')
   end


### PR DESCRIPTION
Added logic to check if it is necessary to attach the no-picture image attachment to the summary mail when there are users displayed without a profile picture.