### PR TITLE
Replaced all Kudo's occurrences with Kudos

### DIFF
--- a/app/jobs/slack/transaction_job.rb
+++ b/app/jobs/slack/transaction_job.rb
@@ -22,7 +22,7 @@ Slack::TransactionJob = Struct.new(:transaction, :new?) do
         attachments: [
             {
                 text: "*#{transaction.sender.name}* gave *#{transaction.receiver_name_feed}* "\
-                      "#{transaction.receiver&.slack_id.present? ? "(<@#{transaction.receiver.slack_id}>)" : ''} "\
+                      "#{transaction.receiver&.slack_id.present? ? "(<@#{transaction.receiver.slack_id}>) " : ''}"\
                       "*<#{transaction_url(transaction)}|#{transaction_amount} #{'₭udo'.pluralize(transaction_amount)}>* "\
                       "for #{transaction.activity_name_feed}. \n\n"\
                       "#{transaction.slack_kudos_left_on_creation > 0 ? "*#{kudos_left} "\

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,5 +1,5 @@
 class Transaction < ActiveRecord::Base
-  validates :amount, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 1000, message: "is not correct. You can't give negative ₭udo's or exceed over 1000" }
+  validates :amount, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 1000, message: "is not correct. You can't give negative ₭udos or exceed over 1000"}
   validates :activity_name_feed, length: {minimum: 4, maximum: 140}
 
   # also creates a second image file with a maximum width and/or height of 800 pixels with its aspect ratio preserved

--- a/app/views/summary_mailer/summary_email.html.haml
+++ b/app/views/summary_mailer/summary_email.html.haml
@@ -4,7 +4,7 @@
     %p
       = "Don't forget to think back about this week, because there is definitely someone who deserves a compliment. \u{1f914}"
     .button-container
-      = link_to "Give ₭udo's!".html_safe, root_url, class: 'btn btn-primary button'
+      = link_to "Give ₭udos!".html_safe, root_url, class: 'btn btn-primary button'
     - if !@reached_goal.nil?
       %table.outer-table
         %tr
@@ -59,7 +59,7 @@
       - if @transactions.empty?
         %tr
           %td.no-transactions-container
-            = "There are no transactions to yet, so start giving ₭udo's to your colleagues! \u{1f628}"
+            = "There are no transactions to yet, so start giving ₭udos to your colleagues! \u{1f628}"
     %p
 
     %table.outer-table

--- a/app/views/transactions/_help-modal.html.haml
+++ b/app/views/transactions/_help-modal.html.haml
@@ -8,15 +8,15 @@
   .modal-body
     .help-container
       %h3
-        How do I give ₭udo's to someone?
+        How do I give ₭udos to someone?
       %p
         To give ₭udos all you have to do is fill out the 3 form fields.
         Click the 'Give Kudos' button and that's it!
     .help-container
       %h3
-        How do I give ₭udo's to multiple colleagues?
+        How do I give ₭udos to multiple colleagues?
       %p
-        You can give ₭udo's to multiple people by giving the Kudo's to them as a team. For example three people on the same project.
+        You can give ₭udos to multiple people by giving the Kudos to them as a team. For example three people on the same project.
     .help-container
       %h3
         How can I add emoji's to my ₭udo transaction?
@@ -26,7 +26,7 @@
         = "in the ₭udo transaction form or by writing a ':' to see a list pop out (e.g. :wink: = \u{1F609})"
     .help-container
       %h3
-        I want to give ₭udo's but I don't know how much, are there guidelines for these cases?
+        I want to give ₭udos but I don't know how much, are there guidelines for these cases?
       %p
         You can read the guidelines via the
         %i.fa.fa-info-circle

--- a/app/views/transactions/_modal-whatsnew.html.haml
+++ b/app/views/transactions/_modal-whatsnew.html.haml
@@ -91,7 +91,7 @@
         %i.fa.fa-chevron-right
         %ul.not-visible
           %li
-            Slack Notifications are send when someone gives kudo's and when a goal is achieved
+            Slack Notifications are send when someone gives Kudos and when a goal is achieved
           %li
             Autocomplete username is working also on Safari and Firefox
           %li

--- a/app/views/transactions/_statistics.html.haml
+++ b/app/views/transactions/_statistics.html.haml
@@ -21,7 +21,7 @@
       %span.statistics-value
         = @all_transactions
   .statistics-main-subtitle
-    ₭udo's
+    ₭udos
   .general-statistics-container.kudos-statistics
     .generalstatistics
       %span.statistics-title

--- a/app/views/user_mailer/welcome_email.html.haml
+++ b/app/views/user_mailer/welcome_email.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td.content
-    = "Welcome to the #{link_to '₭udo-o-Matic', root_url}! We hope you will enjoy your time with us and give a lot of ₭udo's to your colleagues! \u{1f600}".html_safe
+    = "Welcome to the #{link_to '₭udo-o-Matic', root_url}! We hope you will enjoy your time with us and give a lot of ₭udos to your colleagues! \u{1f600}".html_safe
     %ul
       %li
         You will receive notifications regarding activity on the ₭udo-o-Matic via email and Slack.*

--- a/spec/models/goal_reacher_spec.rb
+++ b/spec/models/goal_reacher_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe GoalReacher, type: :model do
     # Skipped because of unused function Transaction.goal_reached_transaction
     xit 'creates a transaction for the reached goal' do
       GoalReacher.check!
-      expect(Transaction.last.activity.name).to eq("reaching the goal #{Goal.previous.name} :boom:, here are some ₭udo's to boost your hunt for the next goal")
+      expect(Transaction.last.activity.name).to eq("reaching the goal #{Goal.previous.name} :boom:, here are some ₭udos to boost your hunt for the next goal")
     end
   end
 end


### PR DESCRIPTION
Replaced all 'Kudo's' occurrences with 'Kudos' so the correct English word is used consistently.