### PR TITLE
Added logic that checks if rufus-scheduler is started by the server

### DIFF
--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -2,11 +2,13 @@ require 'rufus-scheduler'
 
 scheduler = Rufus::Scheduler::singleton
 
-scheduler.cron '0 9 * * 5' do
-  SummaryMailer.new_summary
-end
+unless defined?(Rails::Console) || File.split($0).last == 'rake'
+  scheduler.cron '0 9 * * 5' do
+    SummaryMailer.new_summary
+  end
 
-scheduler.cron '55 10 * * 5' do
-  SlackService.instance.send_reminder
-  FcmService.instance.send_reminder
+  scheduler.cron '55 10 * * 5' do
+    SlackService.instance.send_reminder
+    FcmService.instance.send_reminder
+  end
 end


### PR DESCRIPTION
Added logic that checks if rufus-scheduler is started by the server and ensures that the scheduler is not started by a Rails console or a rake task (worker).