### PR TITLE
Feature 156879333 API V2 Feed

### DIFF
--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -1,0 +1,19 @@
+class Api::V2::ApiController < JSONAPI::ResourceController
+  abstract
+
+  before_action :doorkeeper_authorize!, :set_default_response_format
+
+  def api_user
+    @current_user ||= User.find(doorkeeper_token[:resource_owner_id])
+  end
+
+  private
+
+  def doorkeeper_unauthorized_render_options(error: nil)
+    { json: { error: 'Not authorized' } }
+  end
+
+  def set_default_response_format
+    request.format = :json
+  end
+end

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -3,17 +3,27 @@ class Api::V2::ApiController < JSONAPI::ResourceController
 
   before_action :doorkeeper_authorize!, :set_default_response_format
 
+  # Find the user that owns the access token
   def api_user
-    @current_user ||= User.find(doorkeeper_token[:resource_owner_id])
+    current_resource_owner
   end
 
   private
 
   def doorkeeper_unauthorized_render_options(error: nil)
-    { json: { error: 'Not authorized' } }
+    error_object_overrides = {title: 'Unauthorized',
+                              detail: 'No valid API token was provided.'}
+    {json: {
+        errors: Api::V1::UnauthorizedError.new(error_object_overrides).errors
+    }}
   end
 
   def set_default_response_format
     request.format = :json
+  end
+
+  def current_resource_owner
+    User.find(doorkeeper_token.resource_owner_id) if
+        doorkeeper_token
   end
 end

--- a/app/controllers/api/v2/balances_controller.rb
+++ b/app/controllers/api/v2/balances_controller.rb
@@ -1,0 +1,5 @@
+class Api::V2::BalancesController < Api::V2::ApiController
+  def current
+    redirect_to api_v2_balance_path(Balance.current)
+  end
+end

--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -1,0 +1,17 @@
+class Api::V2::GoalsController < Api::V2::ApiController
+  def next
+    redirect_to api_v2_goal_path(Goal.next)
+  end
+
+  def previous
+    previous_goal = Goal.previous
+
+    if !previous_goal.id.nil?
+      redirect_to api_v2_goal_path(previous_goal)
+    else
+      error_object_overrides = {title: 'Previous goal record not found', detail: 'There is no previous goal record.'}
+      errors = JSONAPI::Exceptions::RecordNotFound.new(nil, error_object_overrides).errors
+      render_errors(errors)
+    end
+  end
+end

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -1,0 +1,62 @@
+class Api::V2::StatisticsController < Api::V2::ApiController
+  GRAPH_MONTHS_OF_DATA = 5
+
+  def general
+    period_week = Time.now.beginning_of_week..Time.now.end_of_week
+    period_month = Time.now.beginning_of_month..Time.now.end_of_month
+
+    transactions_week = transactions_period(period_week)
+    transactions_month = transactions_period(period_month)
+
+    @transactions_week = transactions_week.count
+    @transactions_month = transactions_month.count
+    @transactions_total = Transaction.count
+
+    @kudos_week = transactions_week.sum(:amount) + likes_count_of_period(period_week)
+    @kudos_month = transactions_month.sum(:amount) + likes_count_of_period(period_month)
+    @kudos_total = Transaction.sum(:amount) + likes.count
+  end
+
+  def user
+    @sent_transactions_user = Transaction.where(sender: api_user).count
+    @received_transactions_user = Transaction.where(receiver: api_user).count + received_transactions_company
+    @total_transactions_user = @sent_transactions_user + @received_transactions_user
+  end
+
+  def graph
+    @graph = Hash.new
+
+    (0..GRAPH_MONTHS_OF_DATA - 1).each {|i|
+      month = i.month.ago.beginning_of_month
+      period_month = month..i.month.ago.end_of_month
+      transactions_month = transactions_period(period_month)
+
+      data = {
+          month: month.strftime('%B'),
+          transactions: transactions_month.count,
+          kudos: transactions_month.sum(:amount) + likes_count_of_period(period_month)
+      }
+
+      @graph.store(i, data)
+    }
+  end
+
+  private
+
+  def transactions_period(period)
+    Transaction.where(created_at: period)
+  end
+
+  def likes
+    Transaction.joins("INNER JOIN votes on votes.votable_id = transactions.id and votable_type='Transaction'")
+  end
+
+  def likes_count_of_period(period)
+    likes.where(created_at: period).count
+  end
+
+  def received_transactions_company
+    receiver_company = User.where(name: ENV['COMPANY_USER'])
+    Transaction.where(receiver: receiver_company).count
+  end
+end

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -2,6 +2,8 @@ class Api::V2::StatisticsController < Api::V2::ApiController
   GRAPH_MONTHS_OF_DATA = 5
 
   def general
+    puts 'API_USER'
+    puts api_user
     period_week = Time.now.beginning_of_week..Time.now.end_of_week
     period_month = Time.now.beginning_of_month..Time.now.end_of_month
 
@@ -59,4 +61,5 @@ class Api::V2::StatisticsController < Api::V2::ApiController
     receiver_company = User.where(name: ENV['COMPANY_USER'])
     Transaction.where(receiver: receiver_company).count
   end
+
 end

--- a/app/controllers/api/v2/transactions_controller.rb
+++ b/app/controllers/api/v2/transactions_controller.rb
@@ -1,0 +1,46 @@
+class Api::V2::TransactionsController < Api::V2::ApiController
+  before_action :set_transaction, only: [:like, :unlike]
+  after_action :update_slack_transaction, only: [:like, :unlike]
+
+  def create
+    @transaction = TransactionAdder.create_from_api_request(request.headers, params)
+    @api_user_voted = api_user.voted_on? @transaction
+
+    render 'api/v1/transactions/create', status: :created
+  rescue Exception => e
+    error_object_overrides = {title: 'Transaction could not be created', detail: e}
+    handle_exceptions(JSONAPI::Exceptions::BadRequest.new(error_object_overrides))
+  end
+
+  def like
+    @transaction.liked_by api_user
+
+    render 'api/v1/transactions/like', status: :ok
+  end
+
+  def unlike
+    @transaction.unliked_by api_user
+
+    render 'api/v1/transactions/unlike', status: :ok
+  end
+
+  private
+
+  # context that is used by the Transaction JSONAPI::Resource to generate the value of the 'api_user_voted' attribute
+  def context
+    {api_user: api_user}
+  end
+
+  def set_transaction
+    transaction_id = params[:id]
+    @transaction = Transaction.find(transaction_id)
+  rescue
+    error_object_overrides = {title: 'Transaction record not found',
+                              detail: "The transaction record identified by id #{transaction_id} could not be found."}
+    handle_exceptions(JSONAPI::Exceptions::RecordNotFound.new(transaction_id, error_object_overrides))
+  end
+
+  def update_slack_transaction
+    SlackService.instance.send_updated_transaction(@transaction)
+  end
+end

--- a/app/controllers/api/v2/transactions_controller.rb
+++ b/app/controllers/api/v2/transactions_controller.rb
@@ -6,7 +6,7 @@ class Api::V2::TransactionsController < Api::V2::ApiController
     @transaction = TransactionAdder.create_from_api_request(request.headers, params)
     @api_user_voted = api_user.voted_on? @transaction
 
-    render 'api/v1/transactions/create', status: :created
+    render 'api/v2/transactions/create', status: :created
   rescue Exception => e
     error_object_overrides = {title: 'Transaction could not be created', detail: e}
     handle_exceptions(JSONAPI::Exceptions::BadRequest.new(error_object_overrides))
@@ -15,13 +15,13 @@ class Api::V2::TransactionsController < Api::V2::ApiController
   def like
     @transaction.liked_by api_user
 
-    render 'api/v1/transactions/like', status: :ok
+    render 'api/v2/transactions/like', status: :ok
   end
 
   def unlike
     @transaction.unliked_by api_user
 
-    render 'api/v1/transactions/unlike', status: :ok
+    render 'api/v2/transactions/unlike', status: :ok
   end
 
   private

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,2 +1,7 @@
 class Api::V2::UsersController < Api::V2::ApiController
+
+  def sync
+    render json: current_resource_owner.attributes, status: 200
+  end
+
 end

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -1,0 +1,2 @@
+class Api::V2::UsersController < Api::V2::ApiController
+end

--- a/app/resources/api/v2/balance_resource.rb
+++ b/app/resources/api/v2/balance_resource.rb
@@ -1,0 +1,9 @@
+class Api::V2::BalanceResource < Api::V1::BaseResource
+  attributes :name, :current, :amount
+  filters :name, :current, :amount
+  has_many :transactions
+
+  def amount
+    @model.amount
+  end
+end

--- a/app/resources/api/v2/base_resource.rb
+++ b/app/resources/api/v2/base_resource.rb
@@ -1,0 +1,7 @@
+class Api::V2::BaseResource < JSONAPI::Resource
+  abstract
+
+  primary_key :id
+  attributes :created_at, :updated_at
+  filters :created_at, :updated_at
+end

--- a/app/resources/api/v2/goal_resource.rb
+++ b/app/resources/api/v2/goal_resource.rb
@@ -1,0 +1,5 @@
+class Api::V2::GoalResource < Api::V1::BaseResource
+  attributes :name, :amount, :achieved_on
+  filters :name, :amount, :achieved_on
+  has_one :balance
+end

--- a/app/resources/api/v2/transaction_resource.rb
+++ b/app/resources/api/v2/transaction_resource.rb
@@ -1,0 +1,30 @@
+class Api::V2::TransactionResource < Api::V2::BaseResource
+  attributes :amount, :activity, :votes_count, :api_user_voted, :image_url_original, :image_url_thumb, :image_file_name, :image_content_type, :image_file_size, :image_updated_at
+  filters :amount, :activity, :votes_count, :api_user_voted, :image_url_original, :image_url_thumb, :image_file_name, :image_content_type, :image_file_size, :image_updated_at
+  has_one :sender
+  has_one :receiver
+  has_one :balance
+  paginator :offset
+
+  def activity
+    @model.activity.name
+  end
+
+  def api_user_voted
+    context[:api_user].voted_for? @model
+  end
+
+  def votes_count
+    @model.likes_amount
+  end
+
+  def image_url_original
+    # return nil if the transaction has no original image
+    @model.image.url == '/images/original/missing.png' ? nil : @model.image.url
+  end
+
+  def image_url_thumb
+    # return nil if the transaction has no thumb image
+    @model.image.url(:thumb) == '/images/thumb/missing.png' ? nil : @model.image.url(:thumb)
+  end
+end

--- a/app/resources/api/v2/user_resource.rb
+++ b/app/resources/api/v2/user_resource.rb
@@ -1,0 +1,6 @@
+class Api::V2::UserResource < Api::V2::BaseResource
+  attributes :name, :email, :avatar_url, :admin
+  filters :name, :email, :avatar_url, :admin
+  has_many :sent_transactions
+  has_many :received_transactions
+end

--- a/app/views/api/v2/statistics/general.json.jbuilder
+++ b/app/views/api/v2/statistics/general.json.jbuilder
@@ -1,0 +1,13 @@
+json.data do
+  json.transactions do
+    json.week @transactions_week
+    json.month @transactions_month
+    json.total @transactions_total
+  end
+
+  json.kudos do
+    json.week @kudos_week
+    json.month @kudos_month
+    json.total @kudos_total
+  end
+end

--- a/app/views/api/v2/statistics/graph.json.jbuilder
+++ b/app/views/api/v2/statistics/graph.json.jbuilder
@@ -1,0 +1,3 @@
+json.data do
+  @graph.each {|month, data| json.set! month, data}
+end

--- a/app/views/api/v2/statistics/user.json.jbuilder
+++ b/app/views/api/v2/statistics/user.json.jbuilder
@@ -1,0 +1,5 @@
+json.data do
+  json.sent @sent_transactions_user
+  json.received @received_transactions_user
+  json.total @total_transactions_user
+end

--- a/app/views/api/v2/transactions/create.json.jbuilder
+++ b/app/views/api/v2/transactions/create.json.jbuilder
@@ -1,0 +1,48 @@
+json.key_format! :dasherize
+
+json.data do
+  json.id @transaction.id
+  json.type 'transactions'
+
+  json.links do
+    json.self "#{root_url}api/v2/transactions/#{@transaction.id}"
+  end
+
+  json.attributes do
+    json.created_at @transaction.created_at
+    json.updated_at @transaction.updated_at
+    json.amount @transaction.amount
+    json.activity @transaction.activity.name
+    json.votes_count @transaction.likes_amount
+    json.api_user_voted @api_user_voted
+    json.image_url_original @transaction.image.url == '/images/original/missing.png' ? nil : @transaction.image.url
+    json.image_url_thumb @transaction.image.url == '/images/original/missing.png' ? nil : @transaction.image.url
+    json.image_file_name @transaction.image_file_name
+    json.image_content_type @transaction.image_content_type
+    json.image_file_size @transaction.image_file_size
+    json.image_updated_at @transaction.image_updated_at
+  end
+
+  json.relationships do
+    json.sender do
+      json.links do
+        json.self "#{root_url}api/v2/transactions/#{@transaction.id}/relationships/sender"
+        json.related "#{root_url}api/v2/transactions/#{@transaction.id}/sender"
+      end
+    end
+
+    json.receiver do
+      json.links do
+        json.self "#{root_url}api/v2/transactions/#{@transaction.id}/relationships/receiver"
+        json.related "#{root_url}api/v2/transactions/#{@transaction.id}/receiver"
+      end
+    end
+
+    json.balance do
+      json.links do
+        json.self "#{root_url}api/v2/transactions/#{@transaction.id}/relationships/balance"
+        json.related "#{root_url}api/v2/transactions/#{@transaction.id}/balance"
+      end
+    end
+  end
+end

--- a/app/views/api/v2/transactions/like.json.jbuilder
+++ b/app/views/api/v2/transactions/like.json.jbuilder
@@ -1,0 +1,6 @@
+json.key_format! :dasherize
+
+json.data do
+  json.title 'Successfully liked successfully'
+  json.detail "The transaction record identified by id #{@transaction.id} was liked successfully."
+end

--- a/app/views/api/v2/transactions/unlike.json.jbuilder
+++ b/app/views/api/v2/transactions/unlike.json.jbuilder
@@ -1,0 +1,6 @@
+json.key_format! :dasherize
+
+json.data do
+  json.title 'Successfully unliked successfully'
+  json.detail "The transaction record identified by id #{@transaction.id} was unliked successfully."
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,22 @@ Rails.application.routes.draw do
         post :store_fcm_token
       end
     end
+    namespace :v2 do
+      jsonapi_resources :transactions, only: [:index, :show, :create] do
+        member do
+          put :like, to: 'transactions#like'
+          delete :like, to: 'transactions#unlike'
+        end
+
+        jsonapi_link :sender, only: :show
+        jsonapi_link :receiver, only: :show
+        jsonapi_link :balance, only: :show
+
+        jsonapi_related_resource :sender, only: :show
+        jsonapi_related_resource :receiver, only: :show
+        jsonapi_related_resource :balance, only: :show
+      end
+    end
   end
 
   devise_for :users, controllers: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,27 @@ Rails.application.routes.draw do
       end
     end
     namespace :v2 do
+      jsonapi_resources :balances, only: :show do
+        collection do
+          get :current
+        end
+
+        jsonapi_links :transactions, only: :show
+
+        jsonapi_related_resources :transactions, only: :show
+      end
+
+      jsonapi_resources :goals, only: :show do
+        collection do
+          get :next
+          get :previous
+        end
+
+        jsonapi_link :balance, only: :show
+
+        jsonapi_related_resource :balance, only: :show
+      end
+
       jsonapi_resources :transactions, only: [:index, :show, :create] do
         member do
           put :like, to: 'transactions#like'
@@ -115,6 +136,25 @@ Rails.application.routes.draw do
         jsonapi_related_resource :sender, only: :show
         jsonapi_related_resource :receiver, only: :show
         jsonapi_related_resource :balance, only: :show
+      end
+
+      jsonapi_resources :users, only: [:index, :show] do
+        jsonapi_links :sent_transactions, only: :show
+        jsonapi_links :received_transactions, only: :show
+
+        jsonapi_related_resources :sent_transactions, only: :show
+        jsonapi_related_resources :received_transactions, only: :show
+      end
+
+      scope :statistics, controller: :statistics do
+        get :general
+        get :graph
+        get :user
+      end
+
+      scope :authentication, controller: :authentication do
+        post :obtain_api_token
+        post :store_fcm_token
       end
     end
   end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :application, class: Doorkeeper::Application do
+    name 'RSpec Test'
+    redirect_uri 'urn:ietf:wg:oauth:2.0:oob'
+  end
+end

--- a/spec/requests/api/v2/balances_controller_spec.rb
+++ b/spec/requests/api/v2/balances_controller_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared/api/v1/shared_expectations'
+
+RSpec.describe Api::V2::BalancesController, type: :request do
+  include RequestHelpers
+
+  describe 'GET api/v2/balances/:id' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { "/api/v2/balances/#{balance.id}" }
+    let!(:balance) { create(:balance, :current) }
+    let!(:record_count_before_request) { Balance.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_balance_count_same
+
+      it 'returns the balance associated with the id' do
+        expected =
+          {
+            data: {
+              id: balance.id.to_s,
+              type: 'balances',
+              links: {
+                self: "http://www.example.com#{request}"
+              },
+              attributes: {
+                'created-at': to_api_timestamp_format(balance.created_at),
+                'updated-at': to_api_timestamp_format(balance.updated_at),
+                name: balance.name,
+                current: balance.current,
+                amount: balance.amount
+              },
+              relationships: {
+                transactions: {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/transactions",
+                    related: "http://www.example.com#{request}/transactions"
+                  }
+                }
+              }
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_balance_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_balance_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+end

--- a/spec/requests/api/v2/goals_controller_spec.rb
+++ b/spec/requests/api/v2/goals_controller_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared/api/v1/shared_expectations'
+
+RSpec.describe Api::V2::GoalsController, type: :request do
+  include RequestHelpers
+
+  describe 'GET api/v2/goals/:id' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { "/api/v2/goals/#{goal.id}" }
+    let!(:goal) { create(:goal) }
+    let!(:record_count_before_request) { Goal.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_goal_count_same
+
+      it 'returns the goal associated with the id' do
+        expected =
+          {
+            data: {
+              id: goal.id.to_s,
+              type: 'goals',
+              links: {
+                self: "http://www.example.com#{request}"
+              },
+              attributes: {
+                'created-at': to_api_timestamp_format(goal.created_at),
+                'updated-at': to_api_timestamp_format(goal.updated_at),
+                name: goal.name,
+                amount: goal.amount,
+                'achieved-on': goal.achieved_on
+              },
+              relationships: {
+                balance: {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/balance",
+                    related: "http://www.example.com#{request}/balance"
+                  }
+                }
+              }
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/goals/next' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { '/api/v2/goals/next' }
+
+    context 'with a valid api-token' do
+      context 'and a next goal that is not achieved' do
+        let!(:goal) { create(:goal) }
+        let!(:record_count_before_request) { Goal.count }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        expect_goal_count_same
+
+        it 'redirects to the next goal path' do
+          expect(response).to redirect_to api_v2_goal_path(goal)
+        end
+
+        expect_status_302_found
+      end
+
+      context 'and a next goal that is achieved' do
+        let!(:goal) { create(:goal, :achieved) }
+        let!(:record_count_before_request) { Goal.count }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        expect_goal_count_increase
+
+        it 'redirects to the next goal path' do
+          expect(response).to redirect_to api_v2_goal_path(Goal.last)
+        end
+
+        expect_status_302_found
+      end
+
+      context 'and no next goal' do
+        let!(:record_count_before_request) { Goal.count }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        expect_goal_count_increase
+
+        it 'redirects to the next goal path' do
+          expect(response).to redirect_to api_v2_goal_path(Goal.last)
+        end
+
+        expect_status_302_found
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let!(:record_count_before_request) { Goal.count }
+
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let!(:record_count_before_request) { Goal.count }
+
+      before do
+        get request
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/goals/previous' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { '/api/v2/goals/previous' }
+
+    context 'with a valid api-token' do
+      context 'and a previous goal' do
+        let!(:goal) { create(:goal, :achieved) }
+        let!(:record_count_before_request) { Goal.count }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        expect_goal_count_same
+
+        it 'redirects to the previous goal path' do
+          expect(response).to redirect_to api_v2_goal_path(goal)
+        end
+
+        expect_status_302_found
+      end
+
+      context 'and no previous goal' do
+        let!(:record_count_before_request) { Goal.count }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        expect_goal_count_same
+
+        expect_previous_goal_record_not_found_response
+
+        expect_status_404_not_found
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let!(:record_count_before_request) { Goal.count }
+
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let!(:record_count_before_request) { Goal.count }
+
+      before do
+        get request
+      end
+
+      expect_goal_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+end

--- a/spec/requests/api/v2/statistics_controller_spec.rb
+++ b/spec/requests/api/v2/statistics_controller_spec.rb
@@ -1,0 +1,321 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'shared/api/v1/shared_expectations'
+
+RSpec.describe Api::V2::StatisticsController, type: :request do
+  include RequestHelpers
+
+  describe 'GET api/v2/statistics/general' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let!(:balance) { create(:balance, :current) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { '/api/v2/statistics/general' }
+
+    context 'with a valid api-token' do
+
+
+      context 'and a transaction' do
+        let!(:transaction) { create(:transaction, balance: balance) }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct general statistics' do
+          expected =
+            {
+              data: {
+                transactions: {
+                  week: 1,
+                  month: 1,
+                  total: 1
+                },
+                kudos: {
+                  week: 100,
+                  month: 100,
+                  total: 100
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+
+      context 'and a transaction that has been liked' do
+        let!(:transaction) { create(:transaction, balance: balance) }
+
+        before do
+          transaction.liked_by user
+
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct general statistics' do
+          expected =
+            {
+              data: {
+                transactions: {
+                  week: 1,
+                  month: 1,
+                  total: 1
+                },
+                kudos: {
+                  week: 101,
+                  month: 101,
+                  total: 101
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/statistics/user' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { '/api/v2/statistics/user' }
+
+    context 'with a valid api-token' do
+      let!(:balance) { create(:balance, :current) }
+
+      context 'and a transaction sent by the user' do
+        let!(:transaction) { create(:transaction, balance: balance, sender: user) }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct user statistics' do
+          expected =
+            {
+              data: {
+                sent: 1,
+                received: 0,
+                total: 1
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+
+      context 'and a transaction received by the user' do
+        let!(:transaction) { create(:transaction, balance: balance, receiver: user) }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct user statistics' do
+          expected =
+            {
+              data: {
+                sent: 0,
+                received: 1,
+                total: 1
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/statistics/graph' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { '/api/v2/statistics/graph' }
+
+    context 'with a valid api-token' do
+      let!(:balance) { create(:balance, :current) }
+
+      context 'and a transaction sent in this month' do
+        let!(:transaction) { create(:transaction, balance: balance) }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct graph statistics' do
+          expected =
+            {
+              data: {
+                '0': {
+                  month: month_by_months_ago(0),
+                  transactions: 1,
+                  kudos: 100
+                },
+                '1': {
+                  month: month_by_months_ago(1),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '2': {
+                  month: month_by_months_ago(2),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '3': {
+                  month: month_by_months_ago(3),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '4': {
+                  month: month_by_months_ago(4),
+                  transactions: 0,
+                  kudos: 0
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+
+      context 'and a transaction sent three months ago' do
+        let!(:transaction) { create(:transaction, balance: balance, created_at: 3.months.ago) }
+
+        before do
+          get request, format: :json, access_token: token.token
+        end
+
+        it 'returns the correct graph statistics' do
+          expected =
+            {
+              data: {
+                '0': {
+                  month: month_by_months_ago(0),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '1': {
+                  month: month_by_months_ago(1),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '2': {
+                  month: month_by_months_ago(2),
+                  transactions: 0,
+                  kudos: 0
+                },
+                '3': {
+                  month: month_by_months_ago(3),
+                  transactions: 1,
+                  kudos: 100
+                },
+                '4': {
+                  month: month_by_months_ago(4),
+                  transactions: 0,
+                  kudos: 0
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    private
+
+    def month_by_months_ago(months_ago)
+      months_ago.month.ago.beginning_of_month.strftime('%B')
+    end
+  end
+end

--- a/spec/requests/api/v2/transactions_controller_spec.rb
+++ b/spec/requests/api/v2/transactions_controller_spec.rb
@@ -1,0 +1,808 @@
+require 'rails_helper'
+require 'shared/api/v1/shared_expectations'
+require 'base64'
+
+RSpec.describe Api::V2::TransactionsController, type: :request do
+  include RequestHelpers
+
+  describe 'GET api/v2/transactions' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let (:request) { '/api/v2/transactions' }
+    let! (:transaction1) { create(:transaction, :image) }
+    let! (:transaction2) { create(:transaction) }
+    let! (:record_count_before_request) { Transaction.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_transaction_count_same
+
+      it 'returns all transactions' do
+        expected =
+          {
+            data: [
+              {
+                id: transaction1.id.to_s,
+                type: 'transactions',
+                links: {
+                  self: "http://www.example.com#{request}/#{transaction1.id}"
+                },
+                attributes: {
+                  'created-at': to_api_timestamp_format(transaction1.created_at),
+                  'updated-at': to_api_timestamp_format(transaction1.updated_at),
+                  amount: transaction1.amount,
+                  activity: transaction1.activity.name,
+                  'votes-count': transaction1.likes_amount,
+                  'api-user-voted': (user.voted_on? transaction1),
+                  'image-url-original': transaction1.image.url,
+                  'image-url-thumb': transaction1.image.url(:thumb),
+                  'image-file-name': transaction1.image_file_name,
+                  'image-content-type': transaction1.image_content_type,
+                  'image-file-size': transaction1.image_file_size,
+                  'image-updated-at': to_api_timestamp_format(transaction1.image_updated_at)
+                },
+                relationships: {
+                  sender: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction1.id}/relationships/sender",
+                      related: "http://www.example.com#{request}/#{transaction1.id}/sender"
+                    }
+                  },
+                  receiver: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction1.id}/relationships/receiver",
+                      related: "http://www.example.com#{request}/#{transaction1.id}/receiver"
+                    }
+                  },
+                  balance: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction1.id}/relationships/balance",
+                      related: "http://www.example.com#{request}/#{transaction1.id}/balance"
+                    }
+                  }
+                }
+              },
+              {
+                id: transaction2.id.to_s,
+                type: 'transactions',
+                links: {
+                  self: "http://www.example.com#{request}/#{transaction2.id}"
+                },
+                attributes: {
+                  'created-at': to_api_timestamp_format(transaction2.created_at),
+                  'updated-at': to_api_timestamp_format(transaction2.updated_at),
+                  amount: transaction2.amount,
+                  activity: transaction2.activity.name,
+                  'votes-count': transaction2.likes_amount,
+                  'api-user-voted': (user.voted_on? transaction2),
+                  'image-url-original': nil,
+                  'image-url-thumb': nil,
+                  'image-file-name': nil,
+                  'image-content-type': nil,
+                  'image-file-size': nil,
+                  'image-updated-at': nil
+                },
+                relationships: {
+                  sender: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction2.id}/relationships/sender",
+                      related: "http://www.example.com#{request}/#{transaction2.id}/sender"
+                    }
+                  },
+                  receiver: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction2.id}/relationships/receiver",
+                      related: "http://www.example.com#{request}/#{transaction2.id}/receiver"
+                    }
+                  },
+                  balance: {
+                    links: {
+                      self: "http://www.example.com#{request}/#{transaction2.id}/relationships/balance",
+                      related: "http://www.example.com#{request}/#{transaction2.id}/balance"
+                    }
+                  }
+                }
+              }
+            ],
+            links: {
+              first: "http://www.example.com#{request}?page%5Blimit%5D=10&page%5Boffset%5D=0",
+              last: "http://www.example.com#{request}?page%5Blimit%5D=10&page%5Boffset%5D=0"
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, headers: { 'Api-Token': 'invalid api-token' }
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/transactions?page[limit]=:limit&page[offset]=:offset' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let (:request) { '/api/v2/transactions?page[limit]=1&page[offset]=2' }
+    let! (:transaction1) { create(:transaction) }
+    let! (:transaction2) { create(:transaction) }
+    let! (:transaction3) { create(:transaction) }
+    let! (:transaction4) { create(:transaction) }
+    let! (:transaction5) { create(:transaction) }
+    let! (:record_count_before_request) { Transaction.count }
+
+    context 'with a valid api-token' do
+      let (:user) { create(:user, :api_token) }
+
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_transaction_count_same
+
+      it 'returns a paginated collection of transactions' do
+        expected =
+          {
+            data: [
+              {
+                id: transaction3.id.to_s,
+                type: 'transactions',
+                links: {
+                  self: "http://www.example.com/api/v2/transactions/#{transaction3.id}"
+                },
+                attributes: {
+                  'created-at': to_api_timestamp_format(transaction3.created_at),
+                  'updated-at': to_api_timestamp_format(transaction3.updated_at),
+                  amount: transaction3.amount,
+                  activity: transaction3.activity.name,
+                  'votes-count': transaction3.likes_amount,
+                  'api-user-voted': (user.voted_on? transaction3),
+                  'image-url-original': nil,
+                  'image-url-thumb': nil,
+                  'image-file-name': nil,
+                  'image-content-type': nil,
+                  'image-file-size': nil,
+                  'image-updated-at': nil
+                },
+                relationships: {
+                  sender: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{transaction3.id}/relationships/sender",
+                      related: "http://www.example.com/api/v2/transactions/#{transaction3.id}/sender"
+                    }
+                  },
+                  receiver: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{transaction3.id}/relationships/receiver",
+                      related: "http://www.example.com/api/v2/transactions/#{transaction3.id}/receiver"
+                    }
+                  },
+                  balance: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{transaction3.id}/relationships/balance",
+                      related: "http://www.example.com/api/v2/transactions/#{transaction3.id}/balance"
+                    }
+                  }
+                }
+              }
+            ],
+            links: {
+              first: "http://www.example.com/api/v2/transactions?page%5Blimit%5D=1&page%5Boffset%5D=0",
+              prev: "http://www.example.com/api/v2/transactions?page%5Blimit%5D=1&page%5Boffset%5D=1",
+              next: "http://www.example.com/api/v2/transactions?page%5Blimit%5D=1&page%5Boffset%5D=3",
+              last: "http://www.example.com/api/v2/transactions?page%5Blimit%5D=1&page%5Boffset%5D=4"
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/transactions/:id' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let (:request) { "/api/v2/transactions/#{transaction.id}" }
+    let! (:transaction) { create(:transaction, :image) }
+    let! (:record_count_before_request) { Transaction.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_transaction_count_same
+
+      it 'returns the transaction associated with the id' do
+        expected =
+          {
+            data: {
+              id: transaction.id.to_s,
+              type: 'transactions',
+              links: {
+                self: "http://www.example.com#{request}"
+              },
+              attributes: {
+                'created-at': to_api_timestamp_format(transaction.created_at),
+                'updated-at': to_api_timestamp_format(transaction.updated_at),
+                amount: transaction.amount,
+                activity: transaction.activity.name,
+                'votes-count': transaction.likes_amount,
+                'api-user-voted': (user.voted_on? transaction),
+                'image-url-original': transaction.image.url,
+                'image-url-thumb': transaction.image.url(:thumb),
+                'image-file-name': transaction.image_file_name,
+                'image-content-type': transaction.image_content_type,
+                'image-file-size': transaction.image_file_size,
+                'image-updated-at': to_api_timestamp_format(transaction.image_updated_at)
+              },
+              relationships: {
+                sender: {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/sender",
+                    related: "http://www.example.com#{request}/sender"
+                  }
+                },
+                receiver: {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/receiver",
+                    related: "http://www.example.com#{request}/receiver"
+                  }
+                },
+                balance: {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/balance",
+                    related: "http://www.example.com#{request}/balance"
+                  }
+                }
+              }
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'POST api/v2/transactions' do
+    let(:application) { create(:application) }
+    let(:sender) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: sender.id
+    end
+    let (:request) { "/api/v2/transactions" }
+    let! (:transaction) { build(:transaction) }
+    let! (:receiver) { create(:user, name: 'Receiver') }
+    let! (:balance) { create(:balance, :current) }
+    let! (:record_count_before_request) { Transaction.count }
+
+    context 'with a valid api-token' do
+      context 'and an image attachment' do
+        before do
+          post request,
+               headers: {
+                 'Authorization': "Bearer #{token.token}",
+                 'Content-Type': 'application/vnd.api+json'
+               },
+               params: {
+                 data: {
+                   type: 'transactions',
+                   attributes: {
+                     amount: transaction.amount,
+                     activity: transaction.activity.name,
+                     image: Base64.encode64(File.open(Rails.root + 'spec/fixtures/images/rails.png') { |io| io.read }),
+                     'image-file-type': 'png'
+                   },
+                   relationships: {
+                     receiver: {
+                       data: {
+                         type: 'users',
+                         name: receiver.name
+                       }
+                     }
+                   }
+                 }
+               }.to_json
+        end
+
+        it 'persists the created transaction with an image attachment' do
+          new_transaction = Transaction.find(assigned_id)
+
+          expect(new_transaction.amount).to eq(transaction.amount)
+        end
+
+        expect_transaction_count_increase
+
+        it 'returns the created transaction' do
+          expected =
+            {
+              data: {
+                id: assigned_id,
+                type: 'transactions',
+                links: {
+                  self: "http://www.example.com#{request}/#{assigned_id}"
+                },
+                attributes: {
+                  'created-at': assigned_created_at,
+                  'updated-at': assigned_updated_at,
+                  amount: transaction.amount,
+                  activity: transaction.activity.name,
+                  'votes-count': transaction.likes_amount,
+                  'api-user-voted': (sender.voted_on? transaction),
+                  'image-url-original': json['data']['attributes']['image-url-original'],
+                  'image-url-thumb': json['data']['attributes']['image-url-thumb'],
+                  'image-file-name': 'image.png',
+                  'image-content-type': 'image/png',
+                  'image-file-size': json['data']['attributes']['image-file-size'],
+                  'image-updated-at': json['data']['attributes']['image-updated-at']
+                },
+                relationships: {
+                  sender: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/sender",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/sender"
+                    }
+                  },
+                  receiver: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/receiver",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/receiver"
+                    }
+                  },
+                  balance: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/balance",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/balance"
+                    }
+                  }
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_201_created
+      end
+
+      context 'and without an image attachment' do
+        before do
+          post request,
+               headers: {
+                   'Authorization': "Bearer #{token.token}",
+                 'Content-Type': 'application/vnd.api+json'
+               },
+               params: {
+                 data: {
+                   type: 'transactions',
+                   attributes: {
+                     amount: transaction.amount,
+                     activity: transaction.activity.name
+                   },
+                   relationships: {
+                     receiver: {
+                       data: {
+                         type: 'users',
+                         name: receiver.name
+                       }
+                     }
+                   }
+                 }
+               }.to_json
+        end
+
+        it 'persists the created transaction without an image attachment' do
+          new_transaction = Transaction.find(assigned_id)
+
+          expect(new_transaction.amount).to eq(transaction.amount)
+        end
+
+        expect_transaction_count_increase
+
+        it 'returns the created transaction' do
+          expected =
+            {
+              data: {
+                id: assigned_id,
+                type: 'transactions',
+                links: {
+                  self: "http://www.example.com#{request}/#{assigned_id}"
+                },
+                attributes: {
+                  'created-at': assigned_created_at,
+                  'updated-at': assigned_updated_at,
+                  amount: transaction.amount,
+                  activity: transaction.activity.name,
+                  'votes-count': transaction.likes_amount,
+                  'api-user-voted': (sender.voted_on? transaction),
+                  'image-url-original': nil,
+                  'image-url-thumb': nil,
+                  'image-file-name': nil,
+                  'image-content-type': nil,
+                  'image-file-size': nil,
+                  'image-updated-at': nil
+                },
+                relationships: {
+                  sender: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/sender",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/sender"
+                    }
+                  },
+                  receiver: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/receiver",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/receiver"
+                    }
+                  },
+                  balance: {
+                    links: {
+                      self: "http://www.example.com/api/v2/transactions/#{assigned_id}/relationships/balance",
+                      related: "http://www.example.com/api/v2/transactions/#{assigned_id}/balance"
+                    }
+                  }
+                }
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_201_created
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let(:application) { create(:application) }
+      let(:user) { create(:user) }
+      let(:token) do
+        Doorkeeper::AccessToken.create! application_id: application.id,
+                                        resource_owner_id: user.id
+      end
+      before do
+        post request,
+             headers: {
+                 'Authorization': 'Invalid token',
+               'Content-Type': 'application/vnd.api+json'
+             },
+             params: {
+               data: {
+                 type: 'transactions',
+                 attributes: {
+                   amount: transaction.amount,
+                   activity: transaction.activity.name
+                 },
+                 relationships: {
+                   receiver: {
+                     data: {
+                       type: 'users',
+                       name: receiver.name
+                     }
+                   }
+                 }
+               }
+             }.to_json
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        post request,
+             headers: {
+               'Content-Type': 'application/vnd.api+json'
+             },
+             params: {
+               data: {
+                 data: {
+                   type: 'transactions',
+                   attributes: {
+                     amount: transaction.amount,
+                     activity: transaction.activity.name
+                   },
+                   relationships: {
+                     receiver: {
+                       data: {
+                         type: 'users',
+                         name: receiver.name
+                       }
+                     }
+                   }
+                 }
+               }
+             }.to_json
+      end
+
+      expect_transaction_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'PUT api/v2/transactions/:id/like' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let! (:transaction) { create(:transaction) }
+    let (:user) { create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA') }
+    let (:default_vote_flag) { true }
+    let (:default_vote_scope) { nil }
+    let (:default_vote_weight) { 1 }
+    let (:invalid_transaction_id) { -1 }
+    let (:invalid_user_id) { -1 }
+
+    context 'with a valid api-token' do
+      context 'and a valid transaction id' do
+        let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+        let! (:record_count_before_request) { Vote.count }
+
+        before do
+          put request, format: :json, access_token: token.token
+        end
+
+        it 'persists the vote' do
+          created_vote = Vote.find_by(votable_id: transaction.id, voter_id: user.id)
+
+          expect(created_vote.votable_type).to eq(transaction.class.name)
+          expect(created_vote.votable_id).to eq(transaction.id)
+          expect(created_vote.voter_type).to eq(user.class.name)
+          expect(created_vote.voter_id).to eq(user.id)
+          expect(created_vote.vote_flag).to eq(default_vote_flag)
+          expect(created_vote.vote_scope).to eq(default_vote_scope)
+          expect(created_vote.vote_weight).to eq(default_vote_weight)
+        end
+
+        expect_vote_count_increase
+
+        it 'returns the successfully liked response' do
+          expected =
+            {
+              data: {
+                title: 'Successfully liked successfully',
+                detail: "The transaction record identified by id #{transaction.id} was liked successfully."
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+      context 'an an invalid transaction id' do
+        let (:request) { "/api/v2/transactions/#{invalid_transaction_id}/like" }
+        let! (:record_count_before_request) { Vote.count }
+
+        before do
+          put request, format: :json, access_token: token.token
+        end
+
+        expect_transaction_record_not_found_response
+
+        expect_vote_count_same
+
+        expect_status_404_not_found
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+      let! (:record_count_before_request) { Vote.count }
+
+      before do
+        put request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_vote_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+      let! (:record_count_before_request) { Vote.count }
+
+      before do
+        put request
+      end
+
+      expect_vote_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'DELETE api/v2/transactions/:id/like' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let! (:transaction) { create(:transaction) }
+    let! (:user) { create(:user, api_token: 'X0EfAbSlaeQkXm6gFmNtKA') }
+    let!(:vote) {
+      create(:vote, votable_type: 'Transaction', votable_id: transaction.id, voter_type: 'User', voter_id: user.id)
+    }
+    let (:invalid_transaction_id) { -1 }
+    let (:invalid_user_id) { -1 }
+
+    context 'with a valid api-token' do
+      context 'and a valid transaction id' do
+        let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+        let! (:record_count_before_request) { Vote.count }
+
+        before do
+          delete request, format: :json, access_token: token.token
+        end
+
+        it "deletes the vote associated with the transaction and user id's" do
+          expect { Vote.find(vote.id) }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+        expect_vote_count_decrease
+
+        it 'returns the successfully unliked response' do
+          expected =
+            {
+              data: {
+                title: 'Successfully unliked successfully',
+                detail: "The transaction record identified by id #{transaction.id} was unliked successfully."
+              }
+            }.with_indifferent_access
+
+          expect(json).to eq(expected)
+        end
+
+        expect_status_200_ok
+      end
+
+      context 'an an invalid transaction id' do
+        let (:request) { "/api/v2/transactions/#{invalid_transaction_id}/like" }
+        let! (:record_count_before_request) { Vote.count }
+
+        before do
+          delete request, format: :json, access_token: token.token
+        end
+
+        expect_transaction_record_not_found_response
+
+        expect_vote_count_same
+
+        expect_status_404_not_found
+      end
+    end
+
+    context 'with an invalid api-token' do
+      let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+      let! (:record_count_before_request) { Vote.count }
+
+      before do
+        delete request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_vote_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      let (:request) { "/api/v2/transactions/#{transaction.id}/like" }
+      let! (:record_count_before_request) { Vote.count }
+
+      before do
+        delete request
+      end
+
+      expect_vote_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+end

--- a/spec/requests/api/v2/users_controller_spec.rb
+++ b/spec/requests/api/v2/users_controller_spec.rb
@@ -1,0 +1,204 @@
+require 'rails_helper'
+require 'shared/api/v1/shared_expectations'
+
+RSpec.describe Api::V2::UsersController, type: :request do
+  include RequestHelpers
+
+  describe 'GET api/v2/users' do
+    let(:application) { create(:application) }
+    let!(:user1) { create(:user) }
+    let!(:user2) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user1.id
+    end
+    let(:request) { '/api/v2/users' }
+
+    let!(:record_count_before_request) { User.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_user_count_same
+
+      it 'returns all users' do
+        expected =
+          {
+            data: [
+              {
+                id: user1.id.to_s,
+                type: 'users',
+                links: {
+                  self: "http://www.example.com#{request}/#{user1.id}"
+                },
+                attributes: {
+                  'created-at': to_api_timestamp_format(user1.created_at),
+                  'updated-at': to_api_timestamp_format(user1.updated_at),
+                  name: user1.name,
+                  email: user1.email,
+                  'avatar-url': user1.avatar_url,
+                  admin: user1.admin
+                },
+                relationships: {
+                  'sent-transactions': {
+                    links: {
+                      self: "http://www.example.com#{request}/#{user1.id}/relationships/sent-transactions",
+                      related: "http://www.example.com#{request}/#{user1.id}/sent-transactions"
+                    }
+                  },
+                  'received-transactions': {
+                    links: {
+                      self: "http://www.example.com#{request}/#{user1.id}/relationships/received-transactions",
+                      related: "http://www.example.com#{request}/#{user1.id}/received-transactions"
+                    }
+                  }
+                }
+              },
+              {
+                id: user2.id.to_s,
+                type: 'users',
+                links: {
+                  self: "http://www.example.com#{request}/#{user2.id}"
+                },
+                attributes: {
+                  'created-at': to_api_timestamp_format(user2.created_at),
+                  'updated-at': to_api_timestamp_format(user2.updated_at),
+                  name: user2.name,
+                  email: user2.email,
+                  'avatar-url': user2.avatar_url,
+                  admin: user2.admin
+                },
+                relationships: {
+                  'sent-transactions': {
+                    links: {
+                      self: "http://www.example.com#{request}/#{user2.id}/relationships/sent-transactions",
+                      related: "http://www.example.com#{request}/#{user2.id}/sent-transactions"
+                    }
+                  },
+                  'received-transactions': {
+                    links: {
+                      self: "http://www.example.com#{request}/#{user2.id}/relationships/received-transactions",
+                      related: "http://www.example.com#{request}/#{user2.id}/received-transactions"
+                    }
+                  }
+                }
+              }
+            ]
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_user_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_user_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+
+  describe 'GET api/v2/users/:id' do
+    let(:application) { create(:application) }
+    let(:user) { create(:user) }
+    let(:token) do
+      Doorkeeper::AccessToken.create! application_id: application.id,
+                                      resource_owner_id: user.id
+    end
+    let(:request) { "/api/v2/users/#{user.id}" }
+    let!(:user) { create(:user, :api_token) }
+    let!(:record_count_before_request) { User.count }
+
+    context 'with a valid api-token' do
+      before do
+        get request, format: :json, access_token: token.token
+      end
+
+      expect_user_count_same
+
+      it 'returns the user associated with the id' do
+        expected =
+          {
+            data: {
+              id: user.id.to_s,
+              type: 'users',
+              links: {
+                self: "http://www.example.com#{request}"
+              },
+              attributes: {
+                'created-at': to_api_timestamp_format(user.created_at),
+                'updated-at': to_api_timestamp_format(user.updated_at),
+                name: user.name,
+                email: user.email,
+                'avatar-url': user.avatar_url,
+                admin: user.admin
+              },
+              relationships: {
+                'sent-transactions': {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/sent-transactions",
+                    related: "http://www.example.com#{request}/sent-transactions"
+                  }
+                },
+                'received-transactions': {
+                  links: {
+                    self: "http://www.example.com#{request}/relationships/received-transactions",
+                    related: "http://www.example.com#{request}/received-transactions"
+                  }
+                }
+              }
+            }
+          }.with_indifferent_access
+
+        expect(json).to eq(expected)
+      end
+
+      expect_status_200_ok
+    end
+
+    context 'with an invalid api-token' do
+      before do
+        get request, format: :json, access_token: 'Invalid token'
+      end
+
+      expect_user_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+
+    context 'without an api-token' do
+      before do
+        get request
+      end
+
+      expect_user_count_same
+
+      expect_unauthorized_response
+
+      expect_status_401_unauthorized
+    end
+  end
+end

--- a/spec/resources/api/v2/balance_resource_spec.rb
+++ b/spec/resources/api/v2/balance_resource_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'jsonapi/resources/matchers'
+
+RSpec.describe Api::V2::BalanceResource, type: :resource do
+  let (:balance) {create(:balance)}
+  subject {described_class.new(balance, {})}
+
+  it {is_expected.to have_primary_key :id}
+
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
+  it {is_expected.to have_attribute :name}
+  it {is_expected.to have_attribute :current}
+  it {is_expected.to have_attribute :amount}
+
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :current}
+  it {is_expected.to filter :amount}
+
+  it {is_expected.to have_many :transactions}
+end

--- a/spec/resources/api/v2/goal_resource_spec.rb
+++ b/spec/resources/api/v2/goal_resource_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+require 'jsonapi/resources/matchers'
+
+RSpec.describe Api::V2::GoalResource, type: :resource do
+  let (:goal) {create(:goal)}
+  subject {described_class.new(goal, {})}
+
+  it {is_expected.to have_primary_key :id}
+
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
+  it {is_expected.to have_attribute :name}
+  it {is_expected.to have_attribute :amount}
+  it {is_expected.to have_attribute :achieved_on}
+
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :amount}
+  it {is_expected.to filter :achieved_on}
+
+  it {is_expected.to have_one :balance}
+end

--- a/spec/resources/api/v2/transaction_resource_spec.rb
+++ b/spec/resources/api/v2/transaction_resource_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+require 'jsonapi/resources/matchers'
+
+RSpec.describe Api::V2::TransactionResource, type: :resource do
+  let(:transaction) { create(:transaction) }
+  let(:user) { create(:user) }
+  subject { described_class.new(transaction, api_user: user) }
+
+  it { is_expected.to have_primary_key :id }
+
+  it { is_expected.to have_attribute :created_at }
+  it { is_expected.to have_attribute :updated_at }
+  it { is_expected.to have_attribute :amount }
+  it { is_expected.to have_attribute :activity }
+  it { is_expected.to have_attribute :votes_count }
+  it { is_expected.to have_attribute :api_user_voted }
+  it { is_expected.to have_attribute :image_file_name }
+  it { is_expected.to have_attribute :image_content_type }
+  it { is_expected.to have_attribute :image_file_size }
+  it { is_expected.to have_attribute :image_updated_at }
+  it { is_expected.to have_attribute :image_url_original }
+  it { is_expected.to have_attribute :image_url_thumb }
+
+  it { is_expected.to filter :created_at }
+  it { is_expected.to filter :updated_at }
+  it { is_expected.to filter :amount }
+  it { is_expected.to filter :activity }
+  it { is_expected.to filter :votes_count }
+  it { is_expected.to filter :api_user_voted }
+  it { is_expected.to filter :image_url_original }
+  it { is_expected.to filter :image_url_thumb }
+  it { is_expected.to filter :image_file_name }
+  it { is_expected.to filter :image_content_type }
+  it { is_expected.to filter :image_file_size }
+  it { is_expected.to filter :image_updated_at }
+
+  it { is_expected.to have_one :sender }
+  it { is_expected.to have_one :receiver }
+  it { is_expected.to have_one :balance }
+end

--- a/spec/resources/api/v2/user_resource_spec.rb
+++ b/spec/resources/api/v2/user_resource_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'jsonapi/resources/matchers'
+
+RSpec.describe Api::V2::UserResource, type: :resource do
+  let (:user) {create(:user)}
+  subject {described_class.new(user, {})}
+
+  it {is_expected.to have_primary_key :id}
+
+  it {is_expected.to have_attribute :created_at}
+  it {is_expected.to have_attribute :updated_at}
+  it {is_expected.to have_attribute :name}
+  it {is_expected.to have_attribute :email}
+  it {is_expected.to have_attribute :avatar_url}
+  it {is_expected.to have_attribute :admin}
+
+  it {is_expected.to filter :created_at}
+  it {is_expected.to filter :updated_at}
+  it {is_expected.to filter :name}
+  it {is_expected.to filter :email}
+  it {is_expected.to filter :avatar_url}
+  it {is_expected.to filter :admin}
+
+  it {is_expected.to have_many :sent_transactions}
+  it {is_expected.to have_many :received_transactions}
+end


### PR DESCRIPTION
- Added V2 version of the transactions API endpoint, with Doorkeeper integration. Also added the other endpoints already since it was very easy to migrate from V1.
- Added updated RSpec tests for V2 to work with Doorkeeper (the way that tokens are handled has changed)
- Added a factory for OAuth application, to be used in RSpec API tests