### PR TITLE
Chores #157284862 and #157284899

### DIFF
--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -22,22 +22,23 @@
             Currently waiting confirmation for: #{resource.unconfirmed_email}
         .form-field
           = f.label :name
-          = f.text_field :name, required: false
+          = f.text_field :name, required: false, autocomplete: false
         .form-field
           = f.label :email
-          = f.text_field :email, required: true
+          = f.text_field :email, required: true, autocomplete: false
         .form-field
           = f.label :password
-          = f.password_field :password, required: false, placeholder: 'Leave this empty if you don\'t want to change it'
+          = f.password_field :password, required: false, placeholder: 'Leave this empty if you don\'t want to change it',
+          autocomplete: false
         .form-field
           = f.label :password_confirmation
-          = f.password_field :password_confirmation, required: false
+          = f.password_field :password_confirmation, required: false, autocomplete: false
         .confirm-changes
           .confirm-changes-message
             Confirm your changes by providing your current password
           .form-field
             = f.label :current_password
-            = f.password_field :current_password, required: false
+            = f.password_field :current_password, required: false, autocomplete: false
       .form-actions.actions
         = f.button :submit, "Update", class: 'btn'
     %h2.settings-subtitle

--- a/app/views/users/_personal_info.html.haml
+++ b/app/views/users/_personal_info.html.haml
@@ -23,20 +23,22 @@
     %td.bold
       Slack ID
     %td
-      #{user.slack_id}
+      #{user.slack_id || 'N/A'}
   %tr
     %td.bold
       Slack name
     %td
-      #{user.slack_name}
+      #{user.slack_name || 'N/A'}
   %tr
     %td.bold
       Slack username
     %td
-      #{user.slack_username}
+      #{user.slack_username || 'N/A'}
   %tr
     %td.bold
       Avatar URL
     %td
       - if user.avatar_url
         = link_to 'Show image', user.avatar_url, target: '_blank'
+      - else
+        No image


### PR DESCRIPTION
This PR combines combines chores #157284862 (turn off autocomplete on account edit page) and #157284899 (Show "No data" or something similar in empty fields on the view data page)