### PR TITLE
Disables creation of cron jobs on staging

### DIFF
--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -2,7 +2,7 @@ require 'rufus-scheduler'
 
 scheduler = Rufus::Scheduler::singleton
 
-unless defined?(Rails::Console) || File.split($0).last == 'rake'
+unless defined?(Rails::Console) || File.split($0).last == 'rake' || Rails.env == 'staging'
   scheduler.cron '0 9 * * 5' do
     SummaryMailer.new_summary
   end


### PR DESCRIPTION
Looked with Bart into disabling the cron jobs on staging.
This prevents the creation of the jobs when the current Rails env is staging.