### PR TITLE
Feature 156797190 GDPR Export Background Job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Configuration
 config/database.yml
 
+# User data exports
+/exports
+
 *.swp
 .*
 !/.gitignore

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,80 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- GDPR account restriction feature
+- GDPR data viewing feature
+- GDPR data export feature
+- New API version (V2) with Doorkeeper integration
+- Cron jobs for generating and cleaning up exports
+- Registration form with email confirmation
+- Login form
+- Reset password form
+- Unlock account form
+- Edit account form
+
+### Removed
+- Google login in favor of a regular login and registration form
+
+## [3.1.0] - 2018-01-10
+### Added
+- Receive notifications in the ₭udo-o-Mobile app when you receive ₭udos
+- Receive notifications in the ₭udo-o-Mobile app when a ₭udo goal is reached
+- Receive a weekly ₭udo reminder in the ₭udo-o-Mobile app
+- REST API functionality for retrieving ₭udo-o-Matic usage statistics and historical data
+
+### Changed
+- Made ₭udo-o-Matic notifications less obtrusive in the Slack feed
+- Fixed several Slack-related bugs and improved stability
+
+## [3.0.0] - 2017-12-04
+### Added
+- Receive email when you receive Kudos
+- Receive email when a Kudo goal is reached
+- Receive a weekly Kudo summary email
+- Receive personalized Slack notifications and reminders
+- Give Kudos with the /kudo command in Slack
+- Give Kudos by adding the :kudo: reactji to a message of a Kudo-o-Matic user in Slack
+- Like Kudo transactions using the like button in Slack
+- Settings page for connecting with Slack and configuring mail preferences
+- Single Kudo transaction page, used for sharing transactions by URL
+- Button on the homepage for navigating back to the top
+- User deactivation system
+- Implemented checks that prevent removing important data entries
+- REST API for the upcoming Kudo-o-Mobile app
+- Asynchronous image uploads and Slack communication
+
+## [2.0.1] - 2017-07-15
+### Changed
+- Fixed browser related issues in IE, Safari and Firefox
+
+## [2.0.0] - 2017-07-04
+### Added
+- Like button for transactions
+- Emoji's
+
+### Changed
+- New application design
+- Multiple goals are now visible in the Kudo meter
+- Minor bug fixes
+
+## [1.1.0] - 2017-03-29
+### Added
+- Slack notifications are sent when someone gives Kudo's
+- Slack notifications are sent when a goal is reached
+
+### Changed
+- Minor bug fixes
+
+## [1.0.2] - 2017-03-02
+### Added
+- Feed with last transactions
+
+## [1.0.1] - 2017-03-02
+### Changed
+- Bug fix previous goal
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Feed with last transactions
 
-## [1.0.1] - 2017-03-02
+## [1.0.1] - 2017-01-26
 ### Changed
 - Bug fix previous goal
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'devise', '~> 4.3'
 gem 'doorkeeper', '~> 4.3'
 gem 'delayed_job_active_record', '~> 4.1.1'
 gem 'delayed_paperclip', '~> 3.0.1'
+gem "daemons"
 gem 'draper', '= 3.0.0.pre1'
 gem 'fcm', '~> 0.0.2'
 gem 'font-awesome-rails', '~> 4.7.0.2'
@@ -46,6 +47,7 @@ gem 'railties', '~> 5.0.3'
 gem 'redcarpet', '~> 3.4'
 gem 'rubocop', '~> 0.51.0', require: false
 gem 'rufus-scheduler', '~> 3.4.2'
+gem 'rubyzip', require: 'zip'
 gem 'sass-rails', '~> 5.0'
 gem 'scss_lint', '~> 0.54', require: false
 gem 'simple_form', '~> 3.5'
@@ -66,6 +68,7 @@ end
 group :development do
   gem 'spring', '~> 2.0.2'
   gem 'web-console', '~> 3.0'
+  gem 'rubyzip'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     crass (1.0.4)
     css_parser (1.5.0)
       addressable
+    daemons (1.2.6)
     database_cleaner (1.6.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
@@ -363,6 +364,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_parser (3.9.0)
       sexp_processor (~> 4.1)
+    rubyzip (1.2.1)
     rufus-scheduler (3.4.2)
       et-orbi (~> 1.0)
     sass (3.4.24)
@@ -435,6 +437,7 @@ DEPENDENCIES
   capybara (~> 2.15.1)
   chronic (~> 0.10.2)
   coffee-rails (~> 4.1.0)
+  daemons
   database_cleaner (~> 1.6.1)
   delayed_job_active_record (~> 4.1.1)
   delayed_paperclip (~> 3.0.1)
@@ -476,6 +479,7 @@ DEPENDENCIES
   redcarpet (~> 3.4)
   rspec-rails (~> 3.6)
   rubocop (~> 0.51.0)
+  rubyzip
   rufus-scheduler (~> 3.4.2)
   sass-rails (~> 5.0)
   scss_lint (~> 0.54)

--- a/app/assets/stylesheets/components/_settings.scss
+++ b/app/assets/stylesheets/components/_settings.scss
@@ -19,6 +19,7 @@
 
 .settings-table {
   width: 100%;
+  margin-top: 20px;
   margin-bottom: 20px;
 
   a {

--- a/app/assets/stylesheets/email.scss
+++ b/app/assets/stylesheets/email.scss
@@ -141,10 +141,6 @@ ul {
   border: 1px solid $base-color-lighter-gray;
 }
 
-.sidenote {
-  font-size: $font-size-small;
-}
-
 .signature {
   @extend .body;
 }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,23 @@ class UsersController < ApplicationController
     @likes = @user.votes.page(params[:page]).per(20)
   end
 
+  def export_json
+    Delayed::Job.enqueue Export::CreateExportJob.new(@user, :json)
+    render template: 'users/export_data', locals: { dataformat: 'JSON' }
+  end
+
+  def export_xml
+    Delayed::Job.enqueue Export::CreateExportJob.new(@user, :xml)
+    render template: 'users/export_data', locals: { dataformat: 'XML' }
+  end
+
+  def download_export
+    export = Export.find_by_uuid!(params[:uuid])
+    send_file(
+      export.zip
+    )
+  end
+
   def export
     @transactions = @user.all_transactions
     @votes = @user.votes

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,12 +22,12 @@ class UsersController < ApplicationController
   end
 
   def export_json
-    Delayed::Job.enqueue Export::CreateExportJob.new(@user, :json)
+    ExportService.instance.start_new_export(@user, :json)
     render template: 'users/export_data', locals: { dataformat: 'JSON' }
   end
 
   def export_xml
-    Delayed::Job.enqueue Export::CreateExportJob.new(@user, :xml)
+    ExportService.instance.start_new_export(@user, :xml)
     render template: 'users/export_data', locals: { dataformat: 'XML' }
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   def view_data
     @transactions_count = @user.all_transactions.count
     @votes_count = @user.votes.count
+    @exports = @user.exports
   end
 
   def view_transactions
@@ -35,22 +36,6 @@ class UsersController < ApplicationController
     send_file(
       export.zip
     )
-  end
-
-  def export
-    @transactions = @user.all_transactions
-    @votes = @user.votes
-
-    respond_to do |format|
-      format.json do
-        json_data = render_user_data(:json)
-        send_data(json_data, type: 'text/json; charset=UTF-8;', filename: "#{generate_filename}.json")
-      end
-      format.xml do
-        xml_data = render_user_data(:xml)
-        send_data(xml_data, type: 'text/xml; charset=UTF-8;', filename: "#{generate_filename}.xml")
-      end
-    end
   end
 
   def update
@@ -85,17 +70,4 @@ class UsersController < ApplicationController
                                  :restricted)
   end
 
-  def generate_filename
-    "data_export_#{@user.name.underscore}_#{Time.now.strftime('%Y-%m-%d')}"
-  end
-
-  def render_user_data(format)
-    Rabl.render(@user, 'users/export',
-                view_path: 'app/views',
-                locals: {
-                  transactions: @transactions,
-                  votes: @votes
-                },
-                format: format)
-  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,9 +33,9 @@ class UsersController < ApplicationController
 
   def download_export
     export = Export.find_by_uuid!(params[:uuid])
-    send_file(
-      export.zip
-    )
+    redirect_to export.zip.url
+  rescue ActiveRecord::RecordNotFound
+    render 'users/export_expired'
   end
 
   def update

--- a/app/jobs/export/create_export_job.rb
+++ b/app/jobs/export/create_export_job.rb
@@ -11,7 +11,7 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     export = Export.create(uuid: SecureRandom.uuid, user: user)
 
     # Notify user via email that the export has started
-    UserMailer.export_start_email(user).deliver!
+    UserMailer.export_start_email(user).deliver_now
 
     # Render data in given format (JSON or XML)
     data = render_data(user, transactions, likes, dataformat)
@@ -48,7 +48,7 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     export.save
 
     # Notify user via email that the export is available for download
-    UserMailer.export_done_email(user, export).deliver!
+    UserMailer.export_done_email(user, export).deliver_now
 
     # Delete temporary data file
     File.delete(data_file_path) if File.exist?(data_file_path)

--- a/app/jobs/export/create_export_job.rb
+++ b/app/jobs/export/create_export_job.rb
@@ -9,30 +9,36 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     likes = Vote.all_for_user(user)
     export = Export.create(uuid: SecureRandom.uuid, user: user)
 
+    # Notify user via email that the export has started
     UserMailer.export_start_email(user).deliver_now
+
+    # Render data in given format (JSON or XML)
     data = render_data(user, transactions, likes, dataformat)
-
     data_file_path = generate_data_file_path(user, export, dataformat)
-    dir = File.dirname(data_file_path)
 
+    # Create tmp folder if it doesn't exist
+    dir = File.dirname(data_file_path)
     FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
+    # Write temporary data file
     File.open(data_file_path, 'w') do |f|
       f.write(data)
     end
 
     # Create the zip file and add the data file to it
     zip_file = File.new(
-      Rails.root.join('public', 'exports', 'users', user.id.to_s,
+      Rails.root.join('exports', 'users', user.id.to_s,
                       "export_#{export.uuid}.zip"), 'w'
     )
     Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
       zip.add("user_#{user.id}_data.#{dataformat}", data_file_path)
     end
 
+    # Set file location in Export record
     export.zip = zip_file.path
     export.save
 
+    # Notify user via email that the export is available for download
     UserMailer.export_done_email(user, export).deliver_now
 
     # Delete temporary data file
@@ -56,6 +62,6 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
   end
 
   def generate_data_file_path(user, export, format)
-    Rails.root.join('public', 'exports', 'users', user.id.to_s, 'tmp', "#{export.uuid}_data.#{format}")
+    Rails.root.join('tmp', "#{export.uuid}_data.#{format}")
   end
 end

--- a/app/jobs/export/create_export_job.rb
+++ b/app/jobs/export/create_export_job.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'zip'
+
+Export::CreateExportJob = Struct.new(:user, :dataformat) do
+  def perform
+    transactions = Transaction.all_for_user(user)
+    likes = Vote.all_for_user(user)
+    export = Export.create(uuid: SecureRandom.uuid, user: user)
+
+    UserMailer.export_start_email(user).deliver_now
+    data = render_data(user, transactions, likes, dataformat)
+
+    data_file_path = generate_data_file_path(user, export, dataformat)
+    dir = File.dirname(data_file_path)
+
+    FileUtils.mkdir_p(dir) unless File.directory?(dir)
+
+    File.open(data_file_path, 'w') do |f|
+      f.write(data)
+    end
+
+    # Create the zip file and add the data file to it
+    zip_file = File.new(
+      Rails.root.join('public', 'exports', 'users', user.id.to_s,
+                      "export_#{export.uuid}.zip"), 'w'
+    )
+    Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
+      zip.add("user_#{user.id}_data.#{dataformat}", data_file_path)
+    end
+
+    export.zip = zip_file.path
+    export.save
+
+    UserMailer.export_done_email(user, export).deliver_now
+
+    # Delete temporary data file
+    File.delete(data_file_path) if File.exist?(data_file_path)
+  end
+
+  def queue_name
+    'exports'
+  end
+
+  private
+
+  def render_data(user, transactions, likes, format)
+    Rabl.render(user, 'users/export',
+                view_path: 'app/views',
+                locals: {
+                  transactions: transactions,
+                  votes: likes
+                },
+                format: format)
+  end
+
+  def generate_data_file_path(user, export, format)
+    Rails.root.join('public', 'exports', 'users', user.id.to_s, 'tmp', "#{export.uuid}_data.#{format}")
+  end
+end

--- a/app/jobs/export/create_export_job.rb
+++ b/app/jobs/export/create_export_job.rb
@@ -18,8 +18,7 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     data_file_path = generate_data_file_path(user, export, dataformat)
 
     # Create tmp folder if it doesn't exist
-    dir = File.dirname(data_file_path)
-    FileUtils.mkdir_p(dir) unless File.directory?(dir)
+    FileUtils.mkdir_p(tmp_folder) unless File.directory?(tmp_folder)
 
     # Write temporary data file
     File.open(data_file_path, 'w') do |f|
@@ -29,8 +28,7 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     # Create the zip file and add the data file to it
     tmp_images = []
     zip_file = File.new(
-      Rails.root.join('tmp',
-                      "export_#{user.id}_#{export.uuid}.zip"), 'w'
+      File.join(tmp_folder, "export_#{user.id}_#{export.uuid}.zip"), 'w'
     )
     tmp_imgs_to_delete = []
     Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
@@ -79,11 +77,15 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
                 format: format)
   end
 
+  def tmp_folder
+    Rails.root.join('tmp', 'exports')
+  end
+
   def generate_data_file_path(_user, export, format)
-    Rails.root.join('tmp', "#{export.uuid}_data.#{format}")
+    File.join(tmp_folder, "#{export.uuid}_data.#{format}")
   end
 
   def generate_tmp_img_path(export, filename)
-    Rails.root.join('tmp', "export_#{export.uuid}_#{filename}")
+    File.join(tmp_folder, "#{export.uuid}_img_#{filename}")
   end
 end

--- a/app/jobs/export/create_export_job.rb
+++ b/app/jobs/export/create_export_job.rb
@@ -29,9 +29,10 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
     # Create the zip file and add the data file to it
     tmp_images = []
     zip_file = File.new(
-      Rails.root.join('exports', 'users', user.id.to_s,
-                      "export_#{export.uuid}.zip"), 'w'
+      Rails.root.join('tmp',
+                      "export_#{user.id}_#{export.uuid}.zip"), 'w'
     )
+    tmp_imgs_to_delete = []
     Zip::File.open(zip_file.path, Zip::File::CREATE) do |zip|
       zip.add("user_#{user.id}_data.#{dataformat}", data_file_path)
       transactions.each do |t|
@@ -40,23 +41,26 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
         tmp_images.push(tmp_file_path)
         IO.copy_stream(open(t.image.url), tmp_file_path)
         zip.add("images/#{t.image_file_name}", tmp_file_path)
+        tmp_imgs_to_delete.push tmp_file_path
       end
     end
 
+    # Need to remove the images AFTER closing the zip,
+    # or RubyZip will complain that the images don't exist.
+    tmp_imgs_to_delete.each do |img|
+      File.delete(img) if File.exist?(img)
+    end
+
     # Set file location in Export record
-    export.zip = zip_file.path
+    export.zip = zip_file
     export.save
 
     # Notify user via email that the export is available for download
     UserMailer.export_done_email(user, export).deliver_now
 
-    # Delete temporary data file
+    # Delete local data and zip file
     File.delete(data_file_path) if File.exist?(data_file_path)
-
-    # Delete temporary image files
-    tmp_images.each do |image|
-      File.delete(image) if File.exist?(image)
-    end
+    File.delete(zip_file.path) if File.exist?(zip_file.path)
   end
 
   def queue_name
@@ -75,7 +79,7 @@ Export::CreateExportJob = Struct.new(:user, :dataformat) do
                 format: format)
   end
 
-  def generate_data_file_path(user, export, format)
+  def generate_data_file_path(_user, export, format)
     Rails.root.join('tmp', "#{export.uuid}_data.#{format}")
   end
 

--- a/app/jobs/export/maintain_exports_job.rb
+++ b/app/jobs/export/maintain_exports_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Export::MaintainExportsJob = Struct.new do
+  def perform
+    exports = Export.where('created_at < ?', 1.week.ago)
+    exports.each do |e|
+      File.delete(e.zip) if File.exist?(e.zip)
+    end
+    exports.destroy_all
+  end
+end

--- a/app/jobs/export/maintain_exports_job.rb
+++ b/app/jobs/export/maintain_exports_job.rb
@@ -2,10 +2,6 @@
 
 Export::MaintainExportsJob = Struct.new do
   def perform
-    exports = Export.all_expired
-    exports.each do |e|
-      File.delete(e.zip) if File.exist?(e.zip)
-    end
-    exports.destroy_all
+    Export.all_expired.destroy_all
   end
 end

--- a/app/jobs/export/maintain_exports_job.rb
+++ b/app/jobs/export/maintain_exports_job.rb
@@ -2,7 +2,7 @@
 
 Export::MaintainExportsJob = Struct.new do
   def perform
-    exports = Export.where('created_at < ?', 1.week.ago)
+    exports = Export.all_expired
     exports.each do |e|
       File.delete(e.zip) if File.exist?(e.zip)
     end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,5 +3,10 @@ class ApplicationMailer < ActionMailer::Base
   layout 'mailer'
 
   add_template_helper(TransactionsHelper)
-end
 
+  private
+
+  def logo_attachment
+    File.read("#{Rails.root}/app/assets/images/kudo-o-matic-white-mail.png")
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,8 +8,25 @@ class UserMailer < ApplicationMailer
   def welcome_email(user)
     @user = user
 
-    attachments.inline['logo.png'] = File.read("#{Rails.root}/app/assets/images/kudo-o-matic-white-mail.png")
+    attachments.inline['logo.png'] = logo_attachment
 
     mail(to: user.email, subject: 'Welcome to the ₭udo-o-Matic!')
+  end
+
+  def export_start_email(user)
+    @user = user
+
+    attachments.inline['logo.png'] = logo_attachment
+
+    mail(to: user.email, subject: 'Started data export!')
+  end
+
+  def export_done_email(user, export)
+    @user = user
+
+    attachments.inline['logo.png'] = logo_attachment
+
+    @export = export
+    mail(to: user.email, subject: 'Data export finished!')
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,7 +1,14 @@
 class Export < ActiveRecord::Base
   belongs_to :user
+  before_destroy :delete_file
 
   def self.all_expired
     Export.where('created_at < ?', 1.week.ago)
+  end
+
+  private
+
+  def delete_file
+    File.delete(zip) if File.exist?(zip)
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,0 +1,7 @@
+class Export < ApplicationRecord
+  belongs_to :user
+
+  def zip_path
+    Rails.root.join('public', 'exports', 'users', user.id.to_s, "export_#{uuid}.zip")
+  end
+end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,7 +1,3 @@
 class Export < ApplicationRecord
   belongs_to :user
-
-  def zip_path
-    Rails.root.join('public', 'exports', 'users', user.id.to_s, "export_#{uuid}.zip")
-  end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
 class Export < ActiveRecord::Base
+  has_attached_file :zip
+  validates_attachment_content_type :zip, 
+                                    content_type: %w[application/zip application/x-zip application/x-zip-compressed]
   belongs_to :user
   before_destroy :delete_file
 
@@ -9,6 +13,6 @@ class Export < ActiveRecord::Base
   private
 
   def delete_file
-    File.delete(zip) if File.exist?(zip)
+    zip.destroy
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,3 +1,7 @@
 class Export < ApplicationRecord
   belongs_to :user
+
+  def self.all_expired
+    Export.where('created_at < ?', 1.week.ago)
+  end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,4 +1,4 @@
-class Export < ApplicationRecord
+class Export < ActiveRecord::Base
   belongs_to :user
 
   def self.all_expired

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ActiveRecord::Base
   has_many :sent_transactions, class_name: 'Transaction', foreign_key: :sender_id
   has_many :received_transactions, class_name: 'Transaction', foreign_key: :receiver_id
   has_many :votes, foreign_key: 'voter_id'
+  has_many :exports, foreign_key: 'user_id'
   has_many :fcm_tokens
 
   typed_store :preferences, coder: PreferencesCoder do |p|

--- a/app/services/export_service.rb
+++ b/app/services/export_service.rb
@@ -1,0 +1,11 @@
+class ExportService
+  include Singleton
+
+  def start_new_export(user, format)
+    Delayed::Job.enqueue Export::CreateExportJob.new(user, format)
+  end
+
+  def delete_expired_exports
+    Delayed::Job.enqueue Export::MaintainExportsJob.new
+  end
+end

--- a/app/views/user_mailer/export_done_email.html.haml
+++ b/app/views/user_mailer/export_done_email.html.haml
@@ -1,0 +1,6 @@
+%tr
+  %td.content
+    = "Your data export is ready! \u{1f600}".html_safe
+    %p.sidenote
+      You may download the .zip package at
+      = link_to 'Download', users_download_export_path(uuid: @export.uuid)

--- a/app/views/user_mailer/export_done_email.html.haml
+++ b/app/views/user_mailer/export_done_email.html.haml
@@ -2,5 +2,6 @@
   %td.content
     = "Your data export is ready! \u{1f600}".html_safe
     %p
-      You may download the .zip package
-      = link_to 'here', users_download_export_url(uuid: @export.uuid)
+      The .zip package can be downloaded from
+      = link_to 'here.', users_download_export_url(@export.uuid)
+    %p Your download will be available for 7 days.

--- a/app/views/user_mailer/export_done_email.html.haml
+++ b/app/views/user_mailer/export_done_email.html.haml
@@ -2,5 +2,5 @@
   %td.content
     = "Your data export is ready! \u{1f600}".html_safe
     %p.sidenote
-      You may download the .zip package at
-      = link_to 'Download', users_download_export_url(uuid: @export.uuid)
+      You may download the .zip package
+      = link_to 'here', users_download_export_url(uuid: @export.uuid)

--- a/app/views/user_mailer/export_done_email.html.haml
+++ b/app/views/user_mailer/export_done_email.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td.content
     = "Your data export is ready! \u{1f600}".html_safe
-    %p.sidenote
+    %p
       You may download the .zip package
       = link_to 'here', users_download_export_url(uuid: @export.uuid)

--- a/app/views/user_mailer/export_done_email.html.haml
+++ b/app/views/user_mailer/export_done_email.html.haml
@@ -3,4 +3,4 @@
     = "Your data export is ready! \u{1f600}".html_safe
     %p.sidenote
       You may download the .zip package at
-      = link_to 'Download', users_download_export_path(uuid: @export.uuid)
+      = link_to 'Download', users_download_export_url(uuid: @export.uuid)

--- a/app/views/user_mailer/export_start_email.html.haml
+++ b/app/views/user_mailer/export_start_email.html.haml
@@ -2,4 +2,5 @@
   %td.content
     = "We have just started a data export for you! \u{1f600}".html_safe
     %p.sidenote
-      * You will receive an e-mail with a download link when we're done.
+      If you didn't start a data export, you should secure your account immediately by
+      = link_to 'changing your password.', account_url

--- a/app/views/user_mailer/export_start_email.html.haml
+++ b/app/views/user_mailer/export_start_email.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td.content
     = "We have just started a data export for you! \u{1f600}".html_safe
-    %p.sidenote
+    %p
       If you didn't start a data export, you should secure your account immediately by
       = link_to 'changing your password.', account_url

--- a/app/views/user_mailer/export_start_email.html.haml
+++ b/app/views/user_mailer/export_start_email.html.haml
@@ -1,0 +1,5 @@
+%tr
+  %td.content
+    = "We have just started a data export for you! \u{1f600}".html_safe
+    %p.sidenote
+      * You will receive an e-mail with a download link when we're done.

--- a/app/views/users/_exports_table.html.haml
+++ b/app/views/users/_exports_table.html.haml
@@ -7,6 +7,6 @@
   - exports.each do |e|
     %tr.no-top-border
       %td
-        = link_to "export_#{e.uuid}.zip", e.zip.url
+        = link_to "export_#{e.uuid}.zip", users_download_export_path(e.uuid)
       %td
         = e.created_at.strftime("%Y-%m-%d")

--- a/app/views/users/_exports_table.html.haml
+++ b/app/views/users/_exports_table.html.haml
@@ -1,0 +1,12 @@
+%table.settings-table
+  %tr
+    %th
+      Export
+    %th
+      Exported at
+  - exports.each do |e|
+    %tr.no-top-border
+      %td
+        = link_to "export_#{e.uuid}.zip", users_download_export_path(e.uuid)
+      %td
+        = e.created_at.strftime("%Y-%m-%d")

--- a/app/views/users/_exports_table.html.haml
+++ b/app/views/users/_exports_table.html.haml
@@ -7,6 +7,6 @@
   - exports.each do |e|
     %tr.no-top-border
       %td
-        = link_to "export_#{e.uuid}.zip", users_download_export_path(e.uuid)
+        = link_to "export_#{e.uuid}.zip", e.zip.url
       %td
         = e.created_at.strftime("%Y-%m-%d")

--- a/app/views/users/export_data.html.haml
+++ b/app/views/users/export_data.html.haml
@@ -1,0 +1,18 @@
+= render 'layouts/header'
+.page
+  .settings-container
+    .title-container
+      %h1.settings-title
+        View data
+      .actions
+        = link_to root_path, method: "get", class: 'btn secondary' do
+          <i class="fa fa-home" aria-hidden="true"></i> Home
+        = link_to account_path, method: "get", class: 'btn secondary' do
+          <i class="fa fa-arrow-left" aria-hidden="true"></i> Back to Account
+    %h2.settings-subtitle
+      Export started
+    %p
+      We have started your export, which will include your personal information in
+      = dataformat
+      format and all your uploaded images.
+      You will receive an e-mail with a download link when we're done.

--- a/app/views/users/export_expired.html.haml
+++ b/app/views/users/export_expired.html.haml
@@ -1,0 +1,19 @@
+= render 'layouts/header'
+.page
+  .settings-container
+    .title-container
+      %h1.settings-title
+        Export file not found
+      .actions
+        = link_to root_path, method: "get", class: 'btn secondary' do
+          <i class="fa fa-home" aria-hidden="true"></i> Home
+        = link_to account_path, method: "get", class: 'btn secondary' do
+          <i class="fa fa-arrow-left" aria-hidden="true"></i> Back to Account
+    %p
+      Your export file does not exist or has expired. If you would like to create a new export file, click on one of the
+      buttons below.
+    .data-actions.actions
+      = link_to users_export_json_path, method: "post", class: 'btn' do
+        <i class="fa fa-download" aria-hidden="true"></i> New JSON export
+      = link_to users_export_xml_path, method: "post", class: 'btn' do
+        <i class="fa fa-download" aria-hidden="true"></i> New XML export

--- a/app/views/users/view_data.html.haml
+++ b/app/views/users/view_data.html.haml
@@ -27,11 +27,18 @@
         = link_to users_view_likes_path, method: "get", class: 'btn' do
           <i class="fa fa-eye" aria-hidden="true"></i> View all likes
     %h2.settings-subtitle
-      Export data
-    %p
-      We currently provide data exports in JSON and XML.
+      Data exports
+    -if @exports.any?
+      %p
+        These are your available export files. To download a file, simply click on the link.
+        To create a new export, click on one of the buttons at the bottom of this page.
+      = render 'exports_table', exports: @exports
+    - else
+      %p
+        You don'y have any export files available. To create a export file, click on the of the buttons below.
+        We currently provide data exports in JSON and XML.
     .data-actions.actions
       = link_to users_export_json_path, method: "post", class: 'btn' do
-        <i class="fa fa-download" aria-hidden="true"></i> Download as JSON
+        <i class="fa fa-download" aria-hidden="true"></i> New JSON export
       = link_to users_export_xml_path, method: "post", class: 'btn' do
-        <i class="fa fa-download" aria-hidden="true"></i> Download as XML
+        <i class="fa fa-download" aria-hidden="true"></i> New XML export

--- a/app/views/users/view_data.html.haml
+++ b/app/views/users/view_data.html.haml
@@ -31,7 +31,7 @@
     %p
       We currently provide data exports in JSON and XML.
     .data-actions.actions
-      = link_to users_export_data_path(:format => :json), method: "get", class: 'btn' do
+      = link_to users_export_json_path, method: "post", class: 'btn' do
         <i class="fa fa-download" aria-hidden="true"></i> Download as JSON
-      = link_to users_export_data_path(:format => :xml), method: "get", class: 'btn' do
+      = link_to users_export_xml_path, method: "post", class: 'btn' do
         <i class="fa fa-download" aria-hidden="true"></i> Download as XML

--- a/app/views/users/view_data.html.haml
+++ b/app/views/users/view_data.html.haml
@@ -35,7 +35,7 @@
       = render 'exports_table', exports: @exports
     - else
       %p
-        You don'y have any export files available. To create a export file, click on the of the buttons below.
+        You don't have any export files available. To create a export file, click on one of the buttons below.
         We currently provide data exports in JSON and XML.
     .data-actions.actions
       = link_to users_export_json_path, method: "post", class: 'btn' do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,13 +49,22 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   # SMTP settings for gmail
+  # config.action_mailer.smtp_settings = {
+  #   address: ENV['MAIL_ADDRESS'],
+  #   port: 587,
+  #   user_name: ENV['MAIL_USERNAME'],
+  #   password: ENV['MAIL_PASSWORD'],
+  #   authentication: 'plain',
+  #   enable_starttls_auto: true
+  # }
+  #
   config.action_mailer.smtp_settings = {
-    address: ENV['MAIL_ADDRESS'],
-    port: 587,
-    user_name: ENV['MAIL_USERNAME'],
-    password: ENV['MAIL_PASSWORD'],
-    authentication: 'plain',
-    enable_starttls_auto: true
+      :user_name => '35c8f611a690c6',
+      :password => 'c306d816856515',
+      :address => 'smtp.mailtrap.io',
+      :domain => 'smtp.mailtrap.io',
+      :port => '2525',
+      :authentication => :cram_md5
   }
 
   config.action_mailer.default_url_options = {host: 'localhost', port: 3000}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,22 +49,13 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :smtp
 
   # SMTP settings for gmail
-  # config.action_mailer.smtp_settings = {
-  #   address: ENV['MAIL_ADDRESS'],
-  #   port: 587,
-  #   user_name: ENV['MAIL_USERNAME'],
-  #   password: ENV['MAIL_PASSWORD'],
-  #   authentication: 'plain',
-  #   enable_starttls_auto: true
-  # }
-  #
   config.action_mailer.smtp_settings = {
-      :user_name => '35c8f611a690c6',
-      :password => 'c306d816856515',
-      :address => 'smtp.mailtrap.io',
-      :domain => 'smtp.mailtrap.io',
-      :port => '2525',
-      :authentication => :cram_md5
+    address: ENV['MAIL_ADDRESS'],
+    port: ENV['MAIL_PORT'] || 587,
+    user_name: ENV['MAIL_USERNAME'],
+    password: ENV['MAIL_PASSWORD'],
+    authentication: ENV['MAIL_AUTHENTICATION'] || 'plain',
+    enable_starttls_auto: true
   }
 
   config.action_mailer.default_url_options = {host: 'localhost', port: 3000}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = ENV['DEVISE_SECRET_KEY']
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -12,3 +12,7 @@ unless defined?(Rails::Console) || File.split($0).last == 'rake'
     FcmService.instance.send_reminder
   end
 end
+
+scheduler.cron '5 0 * * *' do
+  ExportService.instance.delete_expired_exports
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,16 +15,20 @@ Rails.application.routes.draw do
 
   get :settings, to: 'users#edit', as: :user
   post :resend_email_confirmation, to: 'users#resend_email_confirmation',
-      as: :users_resend_email_confirmation
+       as: :users_resend_email_confirmation
   patch :settings, to: 'users#update'
+
 
   get :feed, to: 'feed#index'
 
   get 'account/view_data', to: 'users#view_data', as: :users_view_data
   get 'account/view_data/transactions', to: 'users#view_transactions', as: :users_view_transactions
   get 'account/view_data/likes', to: 'users#view_likes', as: :users_view_likes
-  get 'account/export', to: 'users#export', as: :users_export_data
-  
+  # get 'account/export', to: 'users#export', as: :users_export_data
+  post 'account/export/json', to: 'users#export_json', as: :users_export_json
+  post 'account/export/xml', to: 'users#export_xml', as: :users_export_xml
+  get 'account/export/download/:uuid', to: 'users#download_export', as: :users_download_export
+
   get 'legal/privacy'
 
   scope :slack, controller: :slack do
@@ -167,8 +171,8 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, controllers: {
-    omniauth_callbacks: 'users/omniauth_callbacks',
-    registrations: :registrations
+      omniauth_callbacks: 'users/omniauth_callbacks',
+      registrations: :registrations
   }
 
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,6 @@ Rails.application.routes.draw do
   get 'account/view_data', to: 'users#view_data', as: :users_view_data
   get 'account/view_data/transactions', to: 'users#view_transactions', as: :users_view_transactions
   get 'account/view_data/likes', to: 'users#view_likes', as: :users_view_likes
-  # get 'account/export', to: 'users#export', as: :users_export_data
   post 'account/export/json', to: 'users#export_json', as: :users_export_json
   post 'account/export/xml', to: 'users#export_xml', as: :users_export_xml
   get 'account/export/download/:uuid', to: 'users#download_export', as: :users_download_export

--- a/db/migrate/20180511075738_create_exports.rb
+++ b/db/migrate/20180511075738_create_exports.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+class CreateExports < ActiveRecord::Migration[5.0]
+  def change
+    create_table :exports do |t|
+      t.string :uuid
+      t.references :user, foreign_key: true
+      t.string :zip, null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180518091625_add_attachment_zip_to_exports.rb
+++ b/db/migrate/20180518091625_add_attachment_zip_to_exports.rb
@@ -1,0 +1,11 @@
+class AddAttachmentZipToExports < ActiveRecord::Migration
+  def self.up
+    change_table :exports do |t|
+      t.attachment :zip
+    end
+  end
+
+  def self.down
+    remove_attachment :exports, :zip
+  end
+end

--- a/db/migrate/20180518100732_remove_zip_from_users.rb
+++ b/db/migrate/20180518100732_remove_zip_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveZipFromUsers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :exports, :zip
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180511075738) do
+ActiveRecord::Schema.define(version: 20180518091625) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,8 @@ ActiveRecord::Schema.define(version: 20180511075738) do
     t.boolean  "current",    default: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.integer  "team_id"
+    t.index ["team_id"], name: "index_balances_on_team_id", using: :btree
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -48,8 +50,12 @@ ActiveRecord::Schema.define(version: 20180511075738) do
     t.string   "uuid"
     t.integer  "user_id"
     t.string   "zip"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+    t.string   "zip_file_name"
+    t.string   "zip_content_type"
+    t.integer  "zip_file_size"
+    t.datetime "zip_updated_at"
     t.index ["user_id"], name: "index_exports_on_user_id", using: :btree
   end
 
@@ -110,6 +116,27 @@ ActiveRecord::Schema.define(version: 20180511075738) do
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
   end
 
+  create_table "team_members", force: :cascade do |t|
+    t.integer  "team_id"
+    t.integer  "user_id"
+    t.boolean  "admin"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_team_members_on_team_id", using: :btree
+    t.index ["user_id"], name: "index_team_members_on_user_id", using: :btree
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string   "name"
+    t.text     "general_info"
+    t.datetime "created_at",        null: false
+    t.datetime "updated_at",        null: false
+    t.string   "logo_file_name"
+    t.string   "logo_content_type"
+    t.integer  "logo_file_size"
+    t.datetime "logo_updated_at"
+  end
+
   create_table "transactions", force: :cascade do |t|
     t.integer  "sender_id"
     t.integer  "receiver_id"
@@ -125,6 +152,8 @@ ActiveRecord::Schema.define(version: 20180511075738) do
     t.string   "slack_reaction_created_at"
     t.string   "slack_transaction_updated_at"
     t.integer  "slack_kudos_left_on_creation"
+    t.integer  "team_id"
+    t.index ["team_id"], name: "index_transactions_on_team_id", using: :btree
   end
 
   create_table "users", force: :cascade do |t|
@@ -181,4 +210,6 @@ ActiveRecord::Schema.define(version: 20180511075738) do
   add_foreign_key "exports", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "team_members", "teams"
+  add_foreign_key "team_members", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180518091625) do
+ActiveRecord::Schema.define(version: 20180518100732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,6 @@ ActiveRecord::Schema.define(version: 20180518091625) do
   create_table "exports", force: :cascade do |t|
     t.string   "uuid"
     t.integer  "user_id"
-    t.string   "zip"
     t.datetime "created_at",       null: false
     t.datetime "updated_at",       null: false
     t.string   "zip_file_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180504133504) do
+ActiveRecord::Schema.define(version: 20180511075738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,6 +42,15 @@ ActiveRecord::Schema.define(version: 20180504133504) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+  end
+
+  create_table "exports", force: :cascade do |t|
+    t.string   "uuid"
+    t.integer  "user_id"
+    t.string   "zip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_exports_on_user_id", using: :btree
   end
 
   create_table "fcm_tokens", force: :cascade do |t|
@@ -169,6 +178,7 @@ ActiveRecord::Schema.define(version: 20180504133504) do
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope", using: :btree
   end
 
+  add_foreign_key "exports", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
 end


### PR DESCRIPTION
- Implemented background job for exporting the data. On clicking the export button, the user will receive a confirmation screen and email, telling him that the export has started. When the export is available for download, the user will receive another email with the download link.
- Zip file now contains a data file (JSON or XML) and an 'images' folder.
- Added a table where the user can see all available exports.
- Added a background job which deletes exports that are 1 week old.

<img width="1440" alt="screen shot 2018-05-17 at 10 24 39" src="https://user-images.githubusercontent.com/6969657/40165551-97618d60-59bc-11e8-9061-96593d32846c.png">

<img width="600" alt="screen shot 2018-05-17 at 10 24 49" src="https://user-images.githubusercontent.com/6969657/40165556-9a0a64f6-59bc-11e8-96de-2692308591e2.png">

<img width="600" alt="screen shot 2018-05-17 at 10 24 56" src="https://user-images.githubusercontent.com/6969657/40165567-9eeb7398-59bc-11e8-957a-c372c408d255.png">

