### PR TITLE
Bugfix wrong sender name

### DIFF
--- a/app/controllers/api/v2/transactions_controller.rb
+++ b/app/controllers/api/v2/transactions_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::TransactionsController < Api::V2::ApiController
   after_action :update_slack_transaction, only: [:like, :unlike]
 
   def create
-    @transaction = TransactionAdder.create_from_api_request(request.headers, params)
+    @transaction = TransactionAdder.create_from_v2_api_request(api_user, params)
     @api_user_voted = api_user.voted_on? @transaction
 
     render 'api/v2/transactions/create', status: :created

--- a/app/controllers/api/v2/transactions_controller.rb
+++ b/app/controllers/api/v2/transactions_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::TransactionsController < Api::V2::ApiController
   after_action :update_slack_transaction, only: [:like, :unlike]
 
   def create
-    @transaction = TransactionAdder.create_from_v2_api_request(api_user, params)
+    @transaction = TransactionAdder.create_from_api_v2_request(api_user, params)
     @api_user_voted = api_user.voted_on? @transaction
 
     render 'api/v2/transactions/create', status: :created

--- a/app/models/transaction_adder.rb
+++ b/app/models/transaction_adder.rb
@@ -51,6 +51,34 @@ class TransactionAdder
     save transaction
   end
 
+  def self.create_from_v2_api_request(user, params)
+    data = params[:data]
+    attributes = data[:attributes]
+
+    amount = attributes[:amount]
+    receiver_name = data[:relationships][:receiver][:data][:name]
+    receiver = User.where(name: receiver_name).first
+    activity = attributes[:activity]
+    activity = "#{receiver_name} for: #{activity}" if receiver.nil?
+
+    transaction = Transaction.new(
+        amount: amount,
+        activity: Activity.find_or_create_by(name: activity),
+        sender: user,
+        receiver: receiver,
+        slack_kudos_left_on_creation: Goal.next.amount - Balance.current.amount - amount.to_i,
+        balance: Balance.current
+    )
+
+    unless attributes[:image].nil? || attributes['image-file-type'].nil?
+      file_type = attributes['image-file-type']
+      transaction.update(
+          image: "data:image/#{file_type};base64,#{attributes[:image]}", image_file_name: "image.#{file_type}")
+    end
+
+    save transaction
+  end
+
   def self.create_from_slack_command(params)
     text = Formatting.unescape(params['text'])
     arguments = text.split(' ', 3)

--- a/app/models/transaction_adder.rb
+++ b/app/models/transaction_adder.rb
@@ -51,7 +51,7 @@ class TransactionAdder
     save transaction
   end
 
-  def self.create_from_v2_api_request(user, params)
+  def self.create_from_api_v2_request(user, params)
     data = params[:data]
     attributes = data[:attributes]
 

--- a/spec/models/transaction_adder_spec.rb
+++ b/spec/models/transaction_adder_spec.rb
@@ -1,9 +1,82 @@
 require 'rails_helper'
 
 describe TransactionAdder, type: :model do
-  describe '#create' do
-    it 'creates a new transaction' do
+  let(:application) { create(:application) }
+  let(:user) { create(:user) }
+  let(:user2) { create(:user, name: 'Ruud') }
+  let(:user3) { create(:user, name: 'Henk') }
+  let! (:balance) { create(:balance, :current) }
+  let(:token) do
+    Doorkeeper::AccessToken.create! application_id: application.id,
+                                    resource_owner_id: user2.id
+  end
+  let!(:transaction) { build(:transaction) }
 
+  describe '#create_from_api_request' do
+    # This test shows the bug where a transaction with the wrong sender is made
+    # It occurs because the Api-Token header is missing in API V2, which results
+    # in the following database query:
+    #
+    # SELECT  "users".* FROM "users" WHERE "users"."api_token" IS NULL LIMIT 1
+    # So it gets ALL users and then the ordering (created_at) decides which user
+    #
+    # The sender name should equal to Ruud, but it equals to John, the first user
+    context 'with a missing Api-Token header' do
+      it 'creates a transaction with the wrong sender' do
+        headers = {
+          'Authorization': "Bearer #{token.token}",
+          'Content-Type': 'application/vnd.api+json'
+        }
+        params = {
+          data: {
+            type: 'transactions',
+            attributes: {
+              amount: transaction.amount,
+              activity: transaction.activity.name,
+              image: Base64.encode64(File.open(Rails.root + 'spec/fixtures/images/rails.png') { |io| io.read }),
+              'image-file-type': 'png'
+            },
+            relationships: {
+              receiver: {
+                data: {
+                  type: 'users',
+                  name: user.name # John
+                }
+              }
+            }
+          }
+        }
+        transaction = TransactionAdder.create_from_api_request(headers, params)
+        expect(transaction.sender.name).to_not eq(user2.name)
+      end
+    end
+  end
+
+  describe '#create_from_api_v2_request' do
+    # This shows that the new method `create_from_v2_api_request`, creates a
+    # transaction with the right sender. In the controller, the user is given to us by Doorkeeper.
+    it 'creates a transaction with the right sender' do
+      params = {
+        data: {
+          type: 'transactions',
+          attributes: {
+            amount: transaction.amount,
+            activity: transaction.activity.name,
+            image: Base64.encode64(File.open(Rails.root + 'spec/fixtures/images/rails.png') { |io| io.read }),
+            'image-file-type': 'png'
+          },
+          relationships: {
+            receiver: {
+              data: {
+                type: 'users',
+                name: user.name
+              }
+            }
+          }
+        }
+      }
+      transaction = TransactionAdder.create_from_api_v2_request(user2, params)
+      expect(transaction.sender.name).to eq(user2.name)
     end
   end
 end

--- a/spec/requests/api/v2/transactions_controller_spec.rb
+++ b/spec/requests/api/v2/transactions_controller_spec.rb
@@ -354,6 +354,7 @@ RSpec.describe Api::V2::TransactionsController, type: :request do
 
   describe 'POST api/v2/transactions' do
     let(:application) { create(:application) }
+    let! (:receiver) { create(:user, name: 'Receiver') }
     let(:sender) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
@@ -361,7 +362,6 @@ RSpec.describe Api::V2::TransactionsController, type: :request do
     end
     let (:request) { "/api/v2/transactions" }
     let! (:transaction) { build(:transaction) }
-    let! (:receiver) { create(:user, name: 'Receiver') }
     let! (:balance) { create(:balance, :current) }
     let! (:record_count_before_request) { Transaction.count }
 
@@ -451,6 +451,10 @@ RSpec.describe Api::V2::TransactionsController, type: :request do
           expect(json).to eq(expected)
         end
 
+        it 'creates a transaction with the right sender name' do
+          expect(Transaction.last.sender.name).to eq(sender.name)
+        end
+
         expect_status_201_created
       end
 
@@ -535,6 +539,10 @@ RSpec.describe Api::V2::TransactionsController, type: :request do
             }.with_indifferent_access
 
           expect(json).to eq(expected)
+        end
+
+        it 'creates a transaction with the right sender name' do
+          expect(Transaction.last.sender.name).to eq(sender.name)
         end
 
         expect_status_201_created


### PR DESCRIPTION
This PR will *most likely* fix the bug where the wrong sender name is used (we need to test it on staging, so Jeroen can access it). Previously `transaction_adder` would find the sender by using the `Api-Token` header that is provided in the request body. API v2 no longer needs this header, but it was still being used.

I've created another method which will find the user by using the `Authorization` header, which we are using right now. This makes sure that the right sender is added to the transaction.