### PR TITLE
Bug 157993814 api transactions not scoped

### DIFF
--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -27,9 +27,7 @@ class Api::V2::ApiController < JSONAPI::ResourceController
   end
 
 
-
   def current_resource_owner
-    User.find(doorkeeper_token.resource_owner_id) if
-        doorkeeper_token
+    User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end
 end

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -10,11 +10,11 @@ class Api::V2::StatisticsController < Api::V2::ApiController
 
     @transactions_week = transactions_week.count
     @transactions_month = transactions_month.count
-    @transactions_total = Transaction.count
+    @transactions_total = Transaction.where(team_id: current_team.id).count
 
     @kudos_week = transactions_week.sum(:amount) + likes_count_of_period(period_week)
     @kudos_month = transactions_month.sum(:amount) + likes_count_of_period(period_month)
-    @kudos_total = Transaction.sum(:amount) + likes.count
+    @kudos_total = Transaction.where(team_id: current_team.id).sum(:amount) + likes.count
   end
 
   def user
@@ -44,7 +44,7 @@ class Api::V2::StatisticsController < Api::V2::ApiController
   private
 
   def transactions_period(period)
-    Transaction.where(created_at: period)
+    Transaction.where(created_at: period, team_id: current_team.id)
   end
 
   def likes

--- a/app/controllers/api/v2/statistics_controller.rb
+++ b/app/controllers/api/v2/statistics_controller.rb
@@ -10,16 +10,16 @@ class Api::V2::StatisticsController < Api::V2::ApiController
 
     @transactions_week = transactions_week.count
     @transactions_month = transactions_month.count
-    @transactions_total = Transaction.where(team_id: current_team.id).count
+    @transactions_total = current_team.transactions.count
 
     @kudos_week = transactions_week.sum(:amount) + likes_count_of_period(period_week)
     @kudos_month = transactions_month.sum(:amount) + likes_count_of_period(period_month)
-    @kudos_total = Transaction.where(team_id: current_team.id).sum(:amount) + likes.count
+    @kudos_total = current_team.transactions.sum(:amount) + likes.count
   end
 
   def user
-    @sent_transactions_user = Transaction.where(sender: api_user).count
-    @received_transactions_user = Transaction.where(receiver: api_user).count + received_transactions_company
+    @sent_transactions_user = current_team.transactions.where(sender: api_user).count
+    @received_transactions_user = current_team.transactions.where(receiver: api_user).count + received_transactions_company
     @total_transactions_user = @sent_transactions_user + @received_transactions_user
   end
 
@@ -44,11 +44,11 @@ class Api::V2::StatisticsController < Api::V2::ApiController
   private
 
   def transactions_period(period)
-    Transaction.where(created_at: period, team_id: current_team.id)
+    current_team.transactions.where(created_at: period, team_id: current_team.id)
   end
 
   def likes
-    Transaction.joins("INNER JOIN votes on votes.votable_id = transactions.id and votable_type='Transaction'")
+    current_team.transactions.joins("INNER JOIN votes on votes.votable_id = transactions.id and votable_type='Transaction'")
   end
 
   def likes_count_of_period(period)
@@ -56,8 +56,8 @@ class Api::V2::StatisticsController < Api::V2::ApiController
   end
 
   def received_transactions_company
-    receiver_company = User.where(name: ENV['COMPANY_USER'])
-    Transaction.where(receiver: receiver_company).count
+    receiver_company = current_team.users.where(company_user: true)
+    current_team.transactions.where(receiver: receiver_company).count
   end
 
 end

--- a/app/controllers/api/v2/transactions_controller.rb
+++ b/app/controllers/api/v2/transactions_controller.rb
@@ -3,7 +3,7 @@ class Api::V2::TransactionsController < Api::V2::ApiController
   after_action :update_slack_transaction, only: [:like, :unlike]
 
   def create
-    @transaction = TransactionAdder.create_from_api_v2_request(api_user, request.headers['Team'], params)
+    @transaction = TransactionAdder.create_from_api_v2_request(api_user, current_team, params)
     @api_user_voted = api_user.voted_on? @transaction
 
     render 'api/v2/transactions/create', status: :created
@@ -28,7 +28,10 @@ class Api::V2::TransactionsController < Api::V2::ApiController
 
   # context that is used by the Transaction JSONAPI::Resource to generate the value of the 'api_user_voted' attribute
   def context
-    {api_user: api_user}
+    {
+        api_user: api_user,
+        current_team: current_team
+    }
   end
 
   def set_transaction

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -14,6 +14,7 @@ class Team < ActiveRecord::Base
   has_many :balances
   has_many :goals, through: :balances
   has_many :transactions
+  has_many :likes, class_name: 'Vote'
 
   def add_member(user, admin = false)
     TeamMember.create(user: user, team: self, admin: admin)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -13,6 +13,7 @@ class Team < ActiveRecord::Base
   has_many :users, through: :memberships
   has_many :balances
   has_many :goals, through: :balances
+  has_many :transactions
 
   def add_member(user, admin = false)
     TeamMember.create(user: user, team: self, admin: admin)

--- a/app/models/transaction_adder.rb
+++ b/app/models/transaction_adder.rb
@@ -66,10 +66,6 @@ class TransactionAdder
     receiver_name = data[:relationships][:receiver][:data][:name]
     receiver = team.users.where(name: receiver_name).first
 
-    unless receiver.present?
-      raise 'Receiver does not exist in this team'
-    end
-
     activity = attributes[:activity]
     activity = "#{receiver_name} for: #{activity}" if receiver.nil?
 

--- a/app/models/transaction_adder.rb
+++ b/app/models/transaction_adder.rb
@@ -64,23 +64,30 @@ class TransactionAdder
 
     amount = attributes[:amount]
     receiver_name = data[:relationships][:receiver][:data][:name]
-    receiver = User.where(name: receiver_name).first
+    receiver = team.users.where(name: receiver_name).first
+
+    unless receiver.present?
+      raise 'Receiver does not exist in this team'
+    end
+
     activity = attributes[:activity]
     activity = "#{receiver_name} for: #{activity}" if receiver.nil?
 
     transaction = Transaction.new(
-        amount: amount,
-        activity: Activity.find_or_create_by(name: activity),
-        sender: user,
-        receiver: receiver,
-        slack_kudos_left_on_creation: Goal.next(team).amount - Balance.current(team).amount - amount.to_i,
-        balance: Balance.current(team)
+      amount: amount,
+      activity: Activity.find_or_create_by(name: activity),
+      sender: user,
+      receiver: receiver,
+      slack_kudos_left_on_creation: Goal.next(team).amount - Balance.current(team).amount - amount.to_i,
+      balance: Balance.current(team),
+      team_id: team.id
     )
 
     unless attributes[:image].nil? || attributes['image-file-type'].nil?
       file_type = attributes['image-file-type']
       transaction.update(
-          image: "data:image/#{file_type};base64,#{attributes[:image]}", image_file_name: "image.#{file_type}")
+        image: "data:image/#{file_type};base64,#{attributes[:image]}", image_file_name: "image.#{file_type}"
+      )
     end
 
     save transaction, team
@@ -100,7 +107,7 @@ class TransactionAdder
     sender_slack_id = params['user_id']
 
     if arguments.size < 3 || receiver_text.nil? ||
-        sender_slack_id.nil? || amount.nil? || activity.nil? || first_char_receiver != '@'
+       sender_slack_id.nil? || amount.nil? || activity.nil? || first_char_receiver != '@'
       raise SlackArgumentsError, "Invalid command. Use the following syntax to give ₭udos:\n"\
                                     '*/kudo* @receiver <amount> <reason>'
     end
@@ -114,13 +121,13 @@ class TransactionAdder
     raise SlackConnectionError, 'Receiver is *not* connected to the ₭udo-o-Matic' if receiver.nil?
 
     transaction = Transaction.new(
-        amount: amount,
-        activity: Activity.find_or_create_by(name: activity),
-        sender: sender,
-        receiver: receiver,
-        slack_kudos_left_on_creation: Goal.next(team.id).amount - Balance.current(team.id).amount - amount.to_i,
-        balance: Balance.current(team.id),
-        team_id: team.id
+      amount: amount,
+      activity: Activity.find_or_create_by(name: activity),
+      sender: sender,
+      receiver: receiver,
+      slack_kudos_left_on_creation: Goal.next(team.id).amount - Balance.current(team.id).amount - amount.to_i,
+      balance: Balance.current(team.id),
+      team_id: team.id
     )
 
     save(transaction, team)
@@ -150,7 +157,7 @@ class TransactionAdder
   def self.create_for_new_team(team, current_user)
     Transaction.create(
       amount: 1,
-      activity: Activity.find_or_create_by(name: "creating a new team!"),
+      activity: Activity.find_or_create_by(name: 'creating a new team!'),
       sender: team.users.find_by_company_user(true),
       receiver: current_user,
       slack_kudos_left_on_creation: Goal.next(team.id).amount - Balance.current(team.id).amount - 1,
@@ -159,7 +166,7 @@ class TransactionAdder
     )
   end
 
-  private
+  private_class_method
 
   def self.save(transaction, current_team)
     transaction.save!

--- a/app/resources/api/v2/transaction_resource.rb
+++ b/app/resources/api/v2/transaction_resource.rb
@@ -27,4 +27,9 @@ class Api::V2::TransactionResource < Api::V2::BaseResource
     # return nil if the transaction has no thumb image
     @model.image.url(:thumb) == '/images/thumb/missing.png' ? nil : @model.image.url(:thumb)
   end
+
+  def self.records(options = {})
+    context = options[:context]
+    context[:current_team].transactions
+  end
 end

--- a/spec/models/transaction_adder_spec.rb
+++ b/spec/models/transaction_adder_spec.rb
@@ -82,7 +82,7 @@ describe TransactionAdder, type: :model do
           }
         }
       }
-      transaction = TransactionAdder.create_from_api_v2_request(user2, team.id, params)
+      transaction = TransactionAdder.create_from_api_v2_request(user2, team, params)
       expect(transaction.sender.name).to eq(user2.name)
     end
   end

--- a/spec/requests/api/v2/statistics_controller_spec.rb
+++ b/spec/requests/api/v2/statistics_controller_spec.rb
@@ -134,6 +134,10 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
     end
     let(:request) { '/api/v2/statistics/user' }
 
+    before do
+      team.add_member(user)
+    end
+
     context 'with a valid api-token' do
       let!(:balance) { Balance.current(team) }
 

--- a/spec/requests/api/v2/statistics_controller_spec.rb
+++ b/spec/requests/api/v2/statistics_controller_spec.rb
@@ -8,28 +8,35 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
   describe 'GET api/v2/statistics/general' do
     let(:application) { create(:application) }
+    let(:team) { create :team }
     let(:user) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
                                       resource_owner_id: user.id
     end
     let(:application) { create(:application) }
-    let(:user) { create(:user) }
-    let!(:balance) { create(:balance, :current) }
+    let!(:balance) { Balance.current(team) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
                                       resource_owner_id: user.id
     end
     let(:request) { '/api/v2/statistics/general' }
 
+    before do
+      team.add_member(user)
+    end
+
     context 'with a valid api-token' do
 
-
       context 'and a transaction' do
-        let!(:transaction) { create(:transaction, balance: balance) }
+        let!(:transaction) { create(:transaction, balance: balance, team_id: team.id) }
 
         before do
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct general statistics' do
@@ -56,12 +63,16 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
       end
 
       context 'and a transaction that has been liked' do
-        let!(:transaction) { create(:transaction, balance: balance) }
+        let!(:transaction) { create(:transaction, balance: balance, team_id: team.id) }
 
         before do
           transaction.liked_by user
 
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct general statistics' do
@@ -90,7 +101,11 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
     context 'with an invalid api-token' do
       before do
-        get request, format: :json, access_token: 'Invalid token'
+        get request, headers: {
+            'Authorization': "Invalid token",
+            'Content-Type': 'application/vnd.api+json',
+            'Team': team.id
+        }
       end
 
       expect_unauthorized_response
@@ -111,6 +126,7 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
   describe 'GET api/v2/statistics/user' do
     let(:application) { create(:application) }
+    let(:team) { create :team }
     let(:user) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
@@ -119,13 +135,17 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
     let(:request) { '/api/v2/statistics/user' }
 
     context 'with a valid api-token' do
-      let!(:balance) { create(:balance, :current) }
+      let!(:balance) { Balance.current(team) }
 
       context 'and a transaction sent by the user' do
-        let!(:transaction) { create(:transaction, balance: balance, sender: user) }
+        let!(:transaction) { create(:transaction, balance: balance, sender: user, team_id: team.id) }
 
         before do
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct user statistics' do
@@ -145,10 +165,14 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
       end
 
       context 'and a transaction received by the user' do
-        let!(:transaction) { create(:transaction, balance: balance, receiver: user) }
+        let!(:transaction) { create(:transaction, balance: balance, receiver: user, team_id: team.id) }
 
         before do
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct user statistics' do
@@ -170,7 +194,11 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
     context 'with an invalid api-token' do
       before do
-        get request, format: :json, access_token: 'Invalid token'
+        get request, headers: {
+            'Authorization': "Invalid",
+            'Content-Type': 'application/vnd.api+json',
+            'Team': team.id
+        }
       end
 
       expect_unauthorized_response
@@ -191,6 +219,7 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
   describe 'GET api/v2/statistics/graph' do
     let(:application) { create(:application) }
+    let(:team) { create :team }
     let(:user) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
@@ -198,14 +227,22 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
     end
     let(:request) { '/api/v2/statistics/graph' }
 
+    before do
+      team.add_member(user)
+    end
+
     context 'with a valid api-token' do
       let!(:balance) { create(:balance, :current) }
 
       context 'and a transaction sent in this month' do
-        let!(:transaction) { create(:transaction, balance: balance) }
+        let!(:transaction) { create(:transaction, balance: balance, team_id: team.id) }
 
         before do
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct graph statistics' do
@@ -247,10 +284,14 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
       end
 
       context 'and a transaction sent three months ago' do
-        let!(:transaction) { create(:transaction, balance: balance, created_at: 3.months.ago) }
+        let!(:transaction) { create(:transaction, balance: balance, created_at: 3.months.ago, team_id: team.id) }
 
         before do
-          get request, format: :json, access_token: token.token
+          get request, headers: {
+              'Authorization': "Bearer #{token.token}",
+              'Content-Type': 'application/vnd.api+json',
+              'Team': team.id
+          }
         end
 
         it 'returns the correct graph statistics' do
@@ -294,7 +335,11 @@ RSpec.describe Api::V2::StatisticsController, type: :request do
 
     context 'with an invalid api-token' do
       before do
-        get request, format: :json, access_token: 'Invalid token'
+        get request, headers: {
+            'Authorization': "Invalid",
+            'Content-Type': 'application/vnd.api+json',
+            'Team': team.id
+        }
       end
 
       expect_unauthorized_response


### PR DESCRIPTION
This PR fixes a number of issues:
- API V2
    - Transaction POST now adds the transaction to the right team
    - Transaction GET now only returns the transactions for a given team
    - Statisctics GET now only shows the statistics for a given team
- Added a spec for transaction_controller to check if the created transaction has the right Team ID
- Modifed specs of transaction and statistics to work with Team ID's