### PR TITLE
Bug #158326191: API V2 /teams/me returns all invites

### DIFF
--- a/app/controllers/api/v2/teams_controller.rb
+++ b/app/controllers/api/v2/teams_controller.rb
@@ -2,7 +2,7 @@ class Api::V2::TeamsController < Api::V2::ApiController
 
   def me
     @teams = api_user.teams
-    @invites = api_user.team_invites
+    @invites = api_user.team_invites.open
   end
 
 end

--- a/spec/requests/api/v2/teams_controller_spec.rb
+++ b/spec/requests/api/v2/teams_controller_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Api::V2::TeamsController, type: :request do
     let(:team2) { create :team, name: 'The Company', slug: 'the-company' }
     let(:team3) { create :team, name: 'The Invited', slug: 'the-invited' }
     let(:team4) { create :team, name: 'The Second Invited', slug: 'the-second-invited' }
+    let(:team5) { create :team, name: 'The Third Invited', slug: 'the-third-invited' }
     let(:user) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
@@ -19,6 +20,7 @@ RSpec.describe Api::V2::TeamsController, type: :request do
     end
     let!(:invite) { TeamInvite.create(user: user, team: team3) }
     let!(:invite2) { TeamInvite.create(user: user, team: team4, accepted_at: Time.now) }
+    let!(:invite3) { TeamInvite.create(user: user, team: team5, declined_at: Time.now) }
     let(:request) { '/api/v2/teams/me' }
 
     before do

--- a/spec/requests/api/v2/teams_controller_spec.rb
+++ b/spec/requests/api/v2/teams_controller_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe Api::V2::TeamsController, type: :request do
     let(:team) { create(:team) }
     let(:team2) { create :team, name: 'The Company', slug: 'the-company' }
     let(:team3) { create :team, name: 'The Invited', slug: 'the-invited' }
+    let(:team4) { create :team, name: 'The Second Invited', slug: 'the-second-invited' }
     let(:user) { create(:user) }
     let(:token) do
       Doorkeeper::AccessToken.create! application_id: application.id,
                                       resource_owner_id: user.id
     end
     let!(:invite) { TeamInvite.create(user: user, team: team3) }
+    let!(:invite2) { TeamInvite.create(user: user, team: team4, accepted_at: Time.now) }
     let(:request) { '/api/v2/teams/me' }
 
     before do
@@ -29,7 +31,7 @@ RSpec.describe Api::V2::TeamsController, type: :request do
         get request, format: :json, access_token: token.token
       end
 
-      it 'returns a list of teams' do
+      it 'returns a list of teams and one invite' do
         expected =
           {
             data: {


### PR DESCRIPTION
API V2 `/teams/me` would return all invites of a user, not just the pending ones. This PR fixes it.