### PR TITLE
Bug 158328624 API V2 no-picture

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,7 +138,7 @@ class User < ActiveRecord::Base
   def to_profile_json
     Jbuilder.new do |user|
       user.name name
-      user.avatar_url picture_url
+      user.avatar_url avatar_url
     end
   end
 


### PR DESCRIPTION
API V2 `users/me` would include `no-picture.png` as the avatar_url, if the user doesn't have one. However, the mobile app can't find this image. This PR changes it so that avatar_url is `null`, if the user doesn't have a profile picture.