### PR TITLE
Show team logos on selection

### DIFF
--- a/app/assets/stylesheets/components/_layout.scss
+++ b/app/assets/stylesheets/components/_layout.scss
@@ -10,7 +10,7 @@
     display: flex;
     align-items: center;
     height: 100%;
-    h1.team-title{
+    h1.team-title {
       color: #FFFFFF;
     }
   }
@@ -98,6 +98,31 @@
   justify-content: space-between;
 }
 
+.logo-grid {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.team-logo-selection {
+  display: flex;
+  height: 120px;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  background-color: #4b4656;
+  padding: 15px;
+  margin-bottom: 15px;
+  flex: 0 50%;
+  border: 2px solid #FFF;
+  img {
+    max-width: 100%;
+  }
+  &.placeholder {
+    font-size: 18px;
+    color: #FFF;
+  }
+}
+
 @media screen and (max-width: 1200px) {
   .body {
     display: flex;
@@ -177,4 +202,6 @@
     display: block;
   }
 }
+
+
 

--- a/app/views/team_selector/index.html.haml
+++ b/app/views/team_selector/index.html.haml
@@ -30,7 +30,11 @@
     - else
       %h2.settings-subtitle
         Choose your team
-      %ul
+      .logo-grid
         - @teams.each do |t|
-          %li
-            = link_to t.name, dashboard_path(t.slug)
+          -if t.logo.exists?
+            = link_to image_tag(t.logo.url), dashboard_path(t.slug), class: 'team-logo-selection'
+          -else
+            = link_to t.name, dashboard_path(t.slug), class:'team-logo-selection placeholder'
+
+


### PR DESCRIPTION
Now shows the team logos instead of just a name. If the team does not have a logo, show a placeholder rectangle with the name inside.

<img width="1920" alt="screen shot 2018-06-19 at 16 19 57" src="https://user-images.githubusercontent.com/6969657/41603132-a715717e-73dc-11e8-9397-da8b540cf2df.png">
