### PR TITLE
Easy team creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "daemons"
 gem 'draper', '= 3.0.0.pre1'
 gem 'fcm', '~> 0.0.2'
 gem 'font-awesome-rails', '~> 4.7.0.2'
+gem 'friendly_id', '~> 5.1.0'
 gem 'google-id-token', '~> 1.4'
 gem 'haml-rails', '~> 1.0'
 gem 'jbuilder', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       json
     font-awesome-rails (4.7.0.2)
       railties (>= 3.2, < 5.2)
+    friendly_id (5.1.0)
+      activerecord (>= 4.0.0)
     gli (2.17.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -448,6 +450,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.8.0)
   fcm (~> 0.0.2)
   font-awesome-rails (~> 4.7.0.2)
+  friendly_id (~> 5.1.0)
   google-id-token (~> 1.4)
   haml-rails (~> 1.0)
   jbuilder (~> 2.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
 
   def team_by_slug
     if params[:team]
-      Team.find_by_slug!(params[:team])
+      Team.friendly.find(params[:team])
     else
       nil
     end

--- a/app/controllers/team_selector_controller.rb
+++ b/app/controllers/team_selector_controller.rb
@@ -3,8 +3,8 @@
 class TeamSelectorController < ApplicationController
 
   def index
-    # If user has only one team, redirect to that team's dashboard
-    if current_user.teams.one?  && current_user.team_invites.empty?
+    # If user has only one team, and no invites, go to the page of that team
+    if current_user.teams.one?  && current_user.team_invites.open.empty?
       redirect_to dashboard_path(team: current_user.teams.first.slug)
     end
     @teams = current_user.teams

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -49,6 +49,6 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    params.permit(:name, :slug, :general_info, :logo)
+    params.permit(:name, :general_info, :logo)
   end
 end

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -5,7 +5,7 @@ class TeamsController < ApplicationController
   before_action :check_team_admin_rights, only: [:manage]
 
   def new
-    @team = Team.new(team_params)
+    @team = Team.new(create_team_params)
   end
 
   def create
@@ -42,6 +42,10 @@ class TeamsController < ApplicationController
 
   def check_restricted
     redirect_to root_url if current_user.restricted?
+  end
+
+  def create_team_params
+    params.permit(:name)
   end
 
   def team_params

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -2,7 +2,7 @@
 
 class Team < ActiveRecord::Base
   extend FriendlyId
-  friendly_id :name, use: :slugged
+  friendly_id :slug_candidates, use: :slugged
   after_create :setup_team
   after_validation :logo_reverted?
   has_attached_file :logo, styles: { thumb: '320x120' }
@@ -18,6 +18,16 @@ class Team < ActiveRecord::Base
   has_many :goals, through: :balances
   has_many :transactions
   has_many :likes, class_name: 'Vote'
+
+  def slug_candidates
+    %i[name name_and_sequence]
+  end
+
+  def name_and_sequence
+    slug = name.parameterize
+    sequence = Team.where('slug like ?', "#{slug}-%").count + 2
+    "#{slug}-#{sequence}"
+  end
 
   def add_member(user, admin = false)
     TeamMember.create(user: user, team: self, admin: admin)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Team < ActiveRecord::Base
+  extend FriendlyId
+  friendly_id :name, use: :slugged
   after_create :setup_team
   after_validation :logo_reverted?
   has_attached_file :logo, styles: { thumb: '320x120' }

--- a/app/services/team_adder.rb
+++ b/app/services/team_adder.rb
@@ -3,15 +3,9 @@
 class TeamAdder
   def self.create(params, current_user)
     name = params[:name]
-    slug = params[:slug]
-    general_info = params[:general_info]
-    logo = params[:logo]
 
     team = Team.new(
-        name: name,
-        slug: slug,
-        general_info: general_info,
-        logo: logo
+      name: name
     )
 
     save team, current_user

--- a/app/views/teams/new.html.haml
+++ b/app/views/teams/new.html.haml
@@ -17,23 +17,13 @@
     - if @team.errors.any?
       - @team.errors.full_messages.each do |msg|
         .message-container.show-message
-          .margin-bottom{:class => "error-message"}
+          .margin-bottom.error-message
             %span.message
               .fa.fa-exclamation-circle
-              .message{class: :error}= msg
+              .message.error= msg
     = simple_form_for @team, html: { class: 'form' } do |f|
       .form-inputs
         .form-field
-          = f.label :name
-          = f.text_field :name, required: true, autocomplete: false, name: 'name'
-        .form-field
-          = f.label :slug
-          = f.text_field :slug, required: true, autocomplete: false, name: 'slug'
-        .form-field
-          = f.label :general_info
-          = f.text_area :general_info, required: false, autocomplete: false, name: 'general_info'
-        .form-field
-          = f.label :logo
-          = f.input_field :logo, as: :file, id:'media-attachment', name: 'logo'
+          = f.input :name, required: true, autocomplete: false, wrapper: false, input_html: {name: 'name'}
       .form-actions.actions
         = f.button :submit, "Create team", class: 'btn', id: 'create-team-button'

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,88 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w(new edit index session login logout users admin
+    stylesheets assets javascripts images)
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicity opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  #
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/db/migrate/20180620082639_create_friendly_id_slugs.rb
+++ b/db/migrate/20180620082639_create_friendly_id_slugs.rb
@@ -1,0 +1,15 @@
+class CreateFriendlyIdSlugs < ActiveRecord::Migration
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string   :slug,           :null => false
+      t.integer  :sluggable_id,   :null => false
+      t.string   :sluggable_type, :limit => 50
+      t.string   :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, :sluggable_id
+    add_index :friendly_id_slugs, [:slug, :sluggable_type]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], :unique => true
+    add_index :friendly_id_slugs, :sluggable_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180601125208) do
+ActiveRecord::Schema.define(version: 20180620082639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,18 @@ ActiveRecord::Schema.define(version: 20180601125208) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_fcm_tokens_on_user_id", using: :btree
+  end
+
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string   "slug",                      null: false
+    t.integer  "sluggable_id",              null: false
+    t.string   "sluggable_type", limit: 50
+    t.string   "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true, using: :btree
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type", using: :btree
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id", using: :btree
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type", using: :btree
   end
 
   create_table "goals", force: :cascade do |t|

--- a/spec/features/accept_invite_spec.rb
+++ b/spec/features/accept_invite_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Accepting or declining an invite', type: :feature do
   context 'accepting the invite' do
     before do
       find('.invites').click_link("accept-#{invite.id}")
-      expect(current_path).to eql('/')
+      expect(current_path).to eql('/kabisa')
     end
 
     it 'it sets the accepted_at date' do

--- a/spec/features/add_team_spec.rb
+++ b/spec/features/add_team_spec.rb
@@ -22,8 +22,6 @@ RSpec.feature 'Add a team', type: :feature do
   context 'Successfully created team' do
     before do
       fill_in 'team_name', with: 'Kabisa'
-      fill_in 'team_slug', with: 'kabisa'
-      fill_in 'team_general_info', with: 'This is some basic general info'
       click_button 'create-team-button'
     end
 
@@ -45,8 +43,6 @@ RSpec.feature 'Add a team', type: :feature do
   context 'Unsuccessfully created team' do
     before do
       fill_in 'team_name', with: ''
-      fill_in 'team_slug', with: ''
-      fill_in 'team_general_info', with: 'This is some basic general info'
       click_button 'create-team-button'
     end
 
@@ -61,7 +57,6 @@ RSpec.feature 'Add a team', type: :feature do
 
     it 'shows error messages' do
       expect(page).to have_content("Name can't be blank")
-      expect(page).to have_content("Slug can't be blank")
     end
   end
 end


### PR DESCRIPTION
- Creating a team now only requires a name. Slug is handled by the `friendly_id` gem.
- Fixed bug where user would not be redirected to their only team