### PR TITLE
Added reserved keywords to friendly_id initializer

### DIFF
--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # FriendlyId Global Configuration
 #
 # Use this to set up shared configuration options for your entire application.
@@ -16,8 +18,9 @@ FriendlyId.defaults do |config|
   # undesirable to allow as slugs. Edit this list as needed for your app.
   config.use :reserved
 
-  config.reserved_words = %w(new edit index session login logout users admin
-    stylesheets assets javascripts images)
+  config.reserved_words = %w[new edit index session login logout users admin
+                             stylesheets assets javascripts images account teams
+                             settings api]
 
   #  ## Friendly Finders
   #


### PR DESCRIPTION
Added reserved keywords `account`, `teams`, `settings` and `api` to friendly_id initializer.