### PR TITLE
Return goals and balances, instead of redirecting in API V2

### DIFF
--- a/app/controllers/api/v2/balances_controller.rb
+++ b/app/controllers/api/v2/balances_controller.rb
@@ -1,5 +1,11 @@
+# frozen_string_literal: true
+
 class Api::V2::BalancesController < Api::V2::ApiController
   def current
-    redirect_to api_v2_balance_path(Balance.current(current_team.id))
+    balance = Balance.current(current_team.id)
+    balance_resource = JSONAPI::ResourceSerializer.new(Api::V2::BalanceResource).serialize_to_hash(
+      Api::V2::BalanceResource.new(balance, nil)
+    )
+    render json: balance_resource
   end
 end

--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -1,25 +1,29 @@
+# frozen_string_literal: true
+
 class Api::V2::GoalsController < Api::V2::ApiController
   def next
-    # redirect_to api_v2_goal_path(Goal.next(current_team.id))
     goal = Goal.next(current_team.id)
-    goal_resource = JSONAPI::ResourceSerializer.new(Api::V2::GoalResource).serialize_to_hash(
-        Api::V2::GoalResource.new(goal, nil)
-    )
-    render json: goal_resource
+    render_goal goal
   end
 
   def previous
     previous_goal = Goal.previous(current_team.id)
 
     if !previous_goal.id.nil?
-      goal_resource = JSONAPI::ResourceSerializer.new(Api::V2::GoalResource).serialize_to_hash(
-          Api::V2::GoalResource.new(previous_goal, nil)
-      )
-      render json: goal_resource
+      render_goal previous_goal
     else
-      error_object_overrides = {title: 'Previous goal record not found', detail: 'There is no previous goal record.'}
+      error_object_overrides = { title: 'Previous goal record not found', detail: 'There is no previous goal record.' }
       errors = JSONAPI::Exceptions::RecordNotFound.new(nil, error_object_overrides).errors
       render_errors(errors)
     end
+  end
+
+  private
+
+  def render_goal(goal)
+    goal_resource = JSONAPI::ResourceSerializer.new(Api::V2::GoalResource).serialize_to_hash(
+      Api::V2::GoalResource.new(goal, nil)
+    )
+    render json: goal_resource, status: :ok
   end
 end

--- a/app/controllers/api/v2/goals_controller.rb
+++ b/app/controllers/api/v2/goals_controller.rb
@@ -1,13 +1,21 @@
 class Api::V2::GoalsController < Api::V2::ApiController
   def next
-    redirect_to api_v2_goal_path(Goal.next(current_team.id))
+    # redirect_to api_v2_goal_path(Goal.next(current_team.id))
+    goal = Goal.next(current_team.id)
+    goal_resource = JSONAPI::ResourceSerializer.new(Api::V2::GoalResource).serialize_to_hash(
+        Api::V2::GoalResource.new(goal, nil)
+    )
+    render json: goal_resource
   end
 
   def previous
     previous_goal = Goal.previous(current_team.id)
 
     if !previous_goal.id.nil?
-      redirect_to api_v2_goal_path(previous_goal)
+      goal_resource = JSONAPI::ResourceSerializer.new(Api::V2::GoalResource).serialize_to_hash(
+          Api::V2::GoalResource.new(previous_goal, nil)
+      )
+      render json: goal_resource
     else
       error_object_overrides = {title: 'Previous goal record not found', detail: 'There is no previous goal record.'}
       errors = JSONAPI::Exceptions::RecordNotFound.new(nil, error_object_overrides).errors

--- a/app/resources/api/v2/goal_resource.rb
+++ b/app/resources/api/v2/goal_resource.rb
@@ -1,4 +1,6 @@
 class Api::V2::GoalResource < Api::V2::BaseResource
+  model_name 'Goal'
+
   attributes :name, :amount, :achieved_on
   filters :name, :amount, :achieved_on
   has_one :balance

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,7 @@ Rails.application.routes.draw do
         post :store_fcm_token
       end
     end
+
     namespace :v2 do
       jsonapi_resources :balances, only: :show do
         collection do

--- a/spec/requests/api/v2/goals_controller_spec.rb
+++ b/spec/requests/api/v2/goals_controller_spec.rb
@@ -127,11 +127,7 @@ RSpec.describe Api::V2::GoalsController, type: :request do
 
         expect_goal_count_same
 
-        it 'redirects to the next goal path' do
-          expect(response).to redirect_to api_v2_goal_path(goal)
-        end
-
-        expect_status_302_found
+        expect_status_200_ok
       end
 
       context 'and a next goal that is achieved' do
@@ -148,11 +144,7 @@ RSpec.describe Api::V2::GoalsController, type: :request do
 
         expect_goal_count_increase
 
-        it 'redirects to the next goal path' do
-          expect(response).to redirect_to api_v2_goal_path(Goal.last)
-        end
-
-        expect_status_302_found
+        expect_status_200_ok
       end
 
       context 'and no next goal' do
@@ -168,11 +160,7 @@ RSpec.describe Api::V2::GoalsController, type: :request do
 
         expect_goal_count_increase
 
-        it 'redirects to the next goal path' do
-          expect(response).to redirect_to api_v2_goal_path(Goal.last)
-        end
-
-        expect_status_302_found
+        expect_status_200_ok
       end
     end
 
@@ -234,11 +222,7 @@ RSpec.describe Api::V2::GoalsController, type: :request do
 
         expect_goal_count_same
 
-        it 'redirects to the previous goal path' do
-          expect(response).to redirect_to api_v2_goal_path(goal)
-        end
-
-        expect_status_302_found
+        expect_status_200_ok
       end
 
       context 'and no previous goal' do


### PR DESCRIPTION
For some reason, Axios can't handle the 302 responses returned by `api/v2/goals/next`, `api/v2/goals/previous` and `api/v2/balances/current`, in Firefox and Safari. It works perfectly fine in Chrome. This is the cause for the non functioning Goal page on the iOS app.

To fix this, we no longer return a redirect. Instead we directly return the Goal or Balance that the user is looking for.