### PR TITLE
Improved validation for removing balances

### DIFF
--- a/app/models/balance.rb
+++ b/app/models/balance.rb
@@ -48,8 +48,10 @@ class Balance < ActiveRecord::Base
   private
 
   def ensure_a_current_balance_remains
-    if Balance.where(current: true).count < 1
-      raise "Last current balance can't be removed from the system"
+    Team.all.each do |team|
+      if Balance.where(team: team, current: true).count == 0
+        raise "Last current balance for team #{team.name} can't be removed from the system"
+      end
     end
   end
 end

--- a/spec/controllers/admin/balances_controller_spec.rb
+++ b/spec/controllers/admin/balances_controller_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Admin::BalancesController, type: :controller do
 
   describe 'DELETE #destroy' do
     let (:perform_delete) {delete :destroy, params: {id: balance2.id}}
+    let (:perform_delete_active) {delete :destroy, params: {id: balance.id}}
 
     context 'deleting the last current balance' do
       context 'with at least one other current balance left' do
@@ -79,7 +80,7 @@ RSpec.describe Admin::BalancesController, type: :controller do
         let! (:record_count_before_request) {Balance.count}
 
         before do
-          perform_delete
+          perform_delete_active
         end
 
         it 'does not delete the current balance' do

--- a/spec/controllers/admin/balances_controller_spec.rb
+++ b/spec/controllers/admin/balances_controller_spec.rb
@@ -2,8 +2,9 @@ require 'rails_helper'
 require 'shared/controllers/admin/shared_expectations'
 
 RSpec.describe Admin::BalancesController, type: :controller do
-  let!(:team) { create :team }
+  let!(:team) {create :team}
   let!(:balance) {Balance.current(team)}
+  let!(:balance2) {Balance.create team: team, name: 'Balance 2'}
   let!(:user) {create(:user, :admin)}
 
   before do
@@ -13,7 +14,7 @@ RSpec.describe Admin::BalancesController, type: :controller do
   describe 'PATCH #update' do
     let (:perform_update) {patch :update, params: {id: balance.id, balance: balance.attributes}}
 
-    context 'updating the a current balance to a normal balance' do
+    context 'updating the a current balance to a non-current balance' do
       before do
         balance.current = false
       end
@@ -26,15 +27,11 @@ RSpec.describe Admin::BalancesController, type: :controller do
           perform_update
         end
 
-        it 'updates the current balance to a normal balance' do
-          expect(Balance.find(balance.id).current).to eq(false)
+        it 'cant remove the only current balance attached to this team' do
+          expect(Balance.find(balance.id).current).to eq(true)
         end
 
         expect_balance_count_same
-
-        it 'redirects back to the admin balance path' do
-          expect(response).to redirect_to(admin_balance_path)
-        end
       end
 
       context 'with no other current balances left' do
@@ -48,8 +45,6 @@ RSpec.describe Admin::BalancesController, type: :controller do
           expect(Balance.find(balance.id).current).to eq(true)
         end
 
-        expect_balance_count_same
-
         it 'redirects back to the edit admin balance path ' do
           expect(response).to redirect_to(edit_admin_balance_path(balance.id))
         end
@@ -58,7 +53,7 @@ RSpec.describe Admin::BalancesController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let (:perform_delete) {delete :destroy, params: {id: balance.id}}
+    let (:perform_delete) {delete :destroy, params: {id: balance2.id}}
 
     context 'deleting the last current balance' do
       context 'with at least one other current balance left' do
@@ -70,7 +65,7 @@ RSpec.describe Admin::BalancesController, type: :controller do
         end
 
         it 'deletes the current balance' do
-          expect {Balance.find(balance.id)}.to raise_error(ActiveRecord::RecordNotFound)
+          expect {Balance.find(balance2.id)}.to raise_error(ActiveRecord::RecordNotFound)
         end
 
         expect_balance_count_decrease


### PR DESCRIPTION
Previously you were able to remove the only balance linked to a team as long as a current balance existsed, regardless of to which team is was linked. This is fixed with this pr.