### PR TITLE
Respond with 401 when the JWT token is expired

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -15,6 +15,8 @@ class GraphqlController < ApplicationController
     }
     result = KudoOMaticSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
+  rescue TokenExpired => _e
+    render plain: "Unauthorized", status: 401
   rescue => e
     raise e unless Rails.env.development?
     handle_error_in_development e


### PR DESCRIPTION
Currently, when the JWT sent by the client is expired the backend throws a HTTP 500 because the `TokenExpired` exception is not handled.  
This results in the client getting stuck in a state where localStorage needs to be cleared to make the application operable again.

This is one part of the fix. A PR on the frontend will actual handle the 401 introduced by this PR.