### PR TITLE
Generate Slack token for existing users

### DIFF
--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -45,7 +45,8 @@ module Types
           description: 'Is the user a virtual user?'
     field :slackRegistrationToken, String,
           null: true,
-          description: 'Slack connect token'
+          description: 'Slack connect token',
+          resolve: -> (obj, _args, _ctx) {obj.slack_connect_token}
     field :slack_id, String,
           null: true,
           description: 'Slack id'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,14 @@ class User < ApplicationRecord
     p.boolean :summary_mail, default: true
   end
 
+  def slack_connect_token
+    return slack_registration_token unless slack_registration_token.nil?
+
+    self.regenerate_slack_registration_token
+    self.save
+    slack_registration_token
+  end
+
   def member_of?(team)
     memberships.find_by_team_id(team.id).present?
   end


### PR DESCRIPTION
The Slack register token was generated using `has_secure_token` but this will only generate the token when the model is created which will result in a `nil` token for existing users.

To fix this issue a helper method has been added that will regenerate the token if the token does not exist.