### PR TITLE
Slack emoji support

### DIFF
--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -41,11 +41,11 @@ class SlackController < ApplicationController
   end
 
   def auth_team
-    redirect_to SlackService.get_team_oauth_url(params[:team_id]).to_s
+    redirect_to SlackService.get_team_oauth_url(params[:team_id])
   end
 
   def auth_user
-    redirect_to SlackService.get_user_oauth_url(params[:user_id]).to_s
+    redirect_to SlackService.get_user_oauth_url(params[:user_id])
   end
 
   def event

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -22,9 +22,18 @@ class SlackController < ApplicationController
     end
   end
 
-  def auth_callback
+  def team_auth_callback
     begin
-      SlackService.add_to_workspace(params[:code], params[:team_id])
+      SlackService.add_to_workspace(params[:code], params[:team_id], nil)
+      redirect_to Settings.slack_connect_success_url
+    rescue SlackService::InvalidRequest => e
+      render json: {text: "That didn't quite work, #{e}"}
+    end
+  end
+
+  def user_auth_callback
+    begin
+      SlackService.add_to_workspace(params[:code], nil, params[:user_id])
       redirect_to Settings.slack_connect_success_url
     rescue SlackService::InvalidRequest => e
       render json: {text: "That didn't quite work, #{e}"}
@@ -40,8 +49,12 @@ class SlackController < ApplicationController
     end
   end
 
-  def auth
-    redirect_to SlackService.get_oauth_url(params[:team_id]).to_s
+  def auth_team
+    redirect_to SlackService.get_team_oauth_url(params[:team_id], '').to_s
+  end
+
+  def auth_user
+    redirect_to SlackService.get_user_oauth_url('', params[:user_id]).to_s
   end
 
   def reaction

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -59,6 +59,8 @@ class SlackController < ApplicationController
         render status: :ok, json: {ok: true }
         SlackService.reaction_added(params[:team_id], params[:event])
       when 'reaction_removed'
+        render status: :ok, json: {ok: true }
+        SlackService.reaction_removed(params[:team_id], params[:event])
       else
         return render json: {text: 'unsupported event'}
       end

--- a/app/graphql/mutations/post/create_post.rb
+++ b/app/graphql/mutations/post/create_post.rb
@@ -1,5 +1,3 @@
-include SlackService
-
 module Mutations
   class Post::CreatePost < BaseMutation
     null true

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -43,10 +43,6 @@ module Types
     field :virtual_user, Boolean,
           null: true,
           description: 'Is the user a virtual user?'
-    field :slackRegistrationToken, String,
-          null: true,
-          description: 'Slack connect token',
-          resolve: -> (obj, _args, _ctx) {obj.slack_connect_token}
     field :slack_id, String,
           null: true,
           description: 'Slack id'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,6 @@
 
 class User < ApplicationRecord
   validates :name, presence: true
-  has_secure_token :slack_registration_token
 
   after_create :send_welcome_email
 
@@ -41,14 +40,6 @@ class User < ApplicationRecord
     p.boolean :post_received_mail, default: true
     p.boolean :goal_reached_mail, default: true
     p.boolean :summary_mail, default: true
-  end
-
-  def slack_connect_token
-    return slack_registration_token unless slack_registration_token.nil?
-
-    self.regenerate_slack_registration_token
-    self.save
-    slack_registration_token
   end
 
   def member_of?(team)

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -1,4 +1,4 @@
-module SlackService
+class SlackService
   class InvalidRequest < RuntimeError; end
 
   class InvalidCommand < RuntimeError; end
@@ -25,8 +25,10 @@ module SlackService
     sender_string = post.sender.slack_id == nil ? "#{post.sender.name}" : "<@#{post.sender.slack_id}>"
 
     message = "#{sender_string} just gave #{post.amount} kudos to #{get_post_receivers(post)} for #{post.message}"
+    blocks = create_markdown_block(message)
+    blocks << create_post_subscript(post.id)
 
-    client.chat_postMessage(channel: post.team.channel_id, text: message)
+    client.chat_postMessage(channel: post.team.channel_id, blocks: blocks)
   end
 
   def self.connect_account(code, user_id)
@@ -41,8 +43,6 @@ module SlackService
         client_secret: ENV['SLACK_CLIENT_SECRET'],
         redirect_uri: generate_user_redirect_uri(user_id)
     )
-
-    puts auth_result
 
     user = User.find(user_id)
     user.slack_access_token = auth_result[:authed_user][:access_token]
@@ -64,8 +64,6 @@ module SlackService
         redirect_uri: generate_team_redirect_uri(team_id)
     )
 
-    puts auth_result
-
     team = Team.find(team_id)
     team.channel_id = auth_result['incoming_webhook']['channel_id']
     team.slack_bot_access_token = auth_result["access_token"]
@@ -73,6 +71,7 @@ module SlackService
 
     raise InvalidRequest.new("That didn't quite work, #{team.errors.full_messages.join(', ')}") unless team.save
 
+    join_all_channels(team)
     send_welcome_message(team)
   end
 
@@ -110,7 +109,7 @@ module SlackService
     query = {
         redirect_uri: generate_user_redirect_uri(user_id),
         client_id: ENV['SLACK_CLIENT_ID'],
-        scope: Settings.slack_user_scopes,
+        user_scope: Settings.slack_user_scopes,
     }
 
     base_uri.query = query.to_query
@@ -119,29 +118,93 @@ module SlackService
   end
 
   def self.reaction_added(team_id, event)
+    return unless supported_emoji?(event)
+
     team = Team.find_by_slack_team_id(team_id)
     user = User.find_by_slack_id(event[:user])
-    client = Slack::Web::Client.new(token: team.slack_bot_access_token)
+    message = get_message_from_event(team_id, event)
 
-    message = client.conversations_history(channel: event[:item][:channel], latest: event[:item][:ts], limit: 1, inclusive: true)
+    if message_is_kudo_o_matic_post?(message)
+      like_post(user, message)
+    else
+      post = create_post_from_message(team, user, message)
+      update_message_to_post(event[:item][:channel], message, post)
+    end
+  end
 
-    client = Slack::Web::Client.new(token: user.api_token)
+  def self.reaction_removed(team_id, event)
+    return unless supported_emoji?(event)
 
-    newMessage = create_markdown_block(message[:messages][0][:text])
-    newMessage << {
-        type: 'context',
-        block_id: '1',
-        elements: [
-            type: 'mrkdwn',
-            text: '_This message is a Kudo-O-Matic post_'
-        ]
-    }
+    user = User.find_by_slack_id(event[:user])
+    message = get_message_from_event(team_id, event)
 
-    client.chat_update(channel: event[:item][:channel], ts: event[:item][:ts], blocks: newMessage)
-
+    if message_is_kudo_o_matic_post?(message)
+      unlike_post(user, message)
+    end
   end
 
   private
+
+
+  def self.join_all_channels(team)
+    client = Slack::Web::Client.new(token: team.slack_bot_access_token)
+
+    channel_response = client.conversations_list(types: 'public_channel', exclude_archived: true)
+
+    channel_response[:channels].each do |channel|
+      client.conversations_join(channel: channel[:id])
+    end
+  end
+
+  def self.supported_emoji?(event)
+    emojis = Settings.slack_accepted_emojis.split(',')
+
+    emojis.include?(event[:reaction])
+  end
+
+  def self.like_post(user, message)
+    post = Post.find(message[:blocks].last[:block_id])
+
+    post.liked_by(user) unless user.voted_up_on? post
+  end
+
+  def self.unlike_post(user, message)
+    post = Post.find(message[:blocks].last[:block_id])
+
+    post.unliked_by(user) if user.voted_up_on? post
+  end
+
+  def self.get_message_from_event(team_id, event)
+    team = Team.find_by_slack_team_id(team_id)
+    client = Slack::Web::Client.new(token: team.slack_bot_access_token)
+    message_response = client.conversations_history(channel: event[:item][:channel], latest: event[:item][:ts], limit: 1, inclusive: true)
+
+    message_response[:messages][0]
+  end
+
+  def self.create_post_from_message(team, user, slack_message)
+    receiver = User.find_by_slack_id(slack_message[:user])
+
+    raise InvalidRequest.new("That user has not connected their account to Slack.") if receiver == nil
+
+    message = "saying: '#{slack_message[:text]}'"
+
+    begin
+      PostCreator.create_post(message, 1, user, [receiver], team)
+    rescue PostCreator::PostCreateError => e
+      raise InvalidCommand.new(e)
+    end
+  end
+
+  def self.update_message_to_post(channel_id, message, post)
+    user = User.find_by_slack_id(message[:user])
+    client = Slack::Web::Client.new(token: user.slack_access_token)
+
+    new_message = create_markdown_block(message[:text])
+    new_message << create_post_subscript(post.id)
+
+    client.chat_update(channel: channel_id, ts: message[:ts], blocks: new_message)
+  end
 
   def self.generate_base_oauth_url
     URI::HTTP.build(
@@ -268,6 +331,22 @@ module SlackService
              text: text
          }
      }]
+  end
 
+  def self.message_is_kudo_o_matic_post?(message)
+    last_block = message[:blocks].last
+
+    Post.exists?(id: last_block[:block_id])
+  end
+
+  def self.create_post_subscript(post_id)
+    {
+        type: 'context',
+        block_id: post_id.to_s,
+        elements: [
+            type: 'mrkdwn',
+            text: '_This message is a Kudo-O-Matic post_'
+        ]
+    }
   end
 end

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -106,7 +106,7 @@ class SlackService
 
     base_uri.query = query.to_query
 
-    base_uri
+    base_uri.to_s
   end
 
   def self.get_user_oauth_url(user_id)
@@ -120,7 +120,7 @@ class SlackService
 
     base_uri.query = query.to_query
 
-    base_uri
+    base_uri.to_s
   end
 
   def self.reaction_added(team_id, event)

--- a/app/workers/slack_worker.rb
+++ b/app/workers/slack_worker.rb
@@ -1,0 +1,15 @@
+class SlackWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false
+
+  def perform(team_id, event)
+    case event['type']
+    when 'reaction_added'
+      SlackService.reaction_added(team_id, event)
+    when 'reaction_removed'
+      SlackService.reaction_removed(team_id, event)
+    else
+      raise RuntimeError.new('Unsupported event')
+    end
+  end
+end

--- a/config/application.yml
+++ b/config/application.yml
@@ -7,8 +7,8 @@ defaults: &defaults
   slack_post_message_endpoint: 'https://slack.com/api/chat.postMessage'
   slack_connect_success_url: 'http://localhost:9090/#/manage-team/integrations?auth=ok'
   slack_auth_endpoint: 'slack.com'
-  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public'
-  slack_user_scopes: 'reactions:read'
+  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read'
+  slack_user_scopes: 'chat:write'
 
 development:
   <<: *defaults

--- a/config/application.yml
+++ b/config/application.yml
@@ -7,8 +7,9 @@ defaults: &defaults
   slack_post_message_endpoint: 'https://slack.com/api/chat.postMessage'
   slack_team_connect_success_url: 'http://localhost:9090/#/manage-team/integrations?auth=ok'
   slack_user_connect_success_url: 'http://localhost:9090/#/user?auth=ok'
+  slack_accepted_emojis: 'kudos-development'
   slack_auth_endpoint: 'slack.com'
-  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history'
+  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join'
   slack_user_scopes: 'chat:write'
 
 development:
@@ -17,7 +18,9 @@ development:
 
 staging:
   <<: *defaults
-  slack_connect_success_url: 'https://kudos.develop.kabisa.io/#/manage-team/integrations?auth=ok'
+  slack_team_connect_success_url: 'https://kudos.develop.kabisa.io/#/manage-team/integrations?auth=ok'
+  slack_user_connect_success_url: 'https://kudos.develop.kabisa.io/#/user?auth=ok'
+  slack_accepted_emojis: 'kudos-staging'
 
 test:
   <<: *defaults
@@ -27,4 +30,6 @@ test:
 
 production:
   <<: *defaults
-  slack_connect_success_url: 'https://kudos.kabisa.io/#/manage-team/integrations?auth=ok'
+  slack_team_connect_success_url: 'https://kudos.kabisa.io/#/manage-team/integrations?auth=ok'
+  slack_user_connect_success_url: 'https://kudos.kabisa.io/#/user?auth=ok'
+  slack_accepted_emojis: 'kudos'

--- a/config/application.yml
+++ b/config/application.yml
@@ -5,9 +5,10 @@ defaults: &defaults
   gravatar_size: '200'
   slack_acccess_token_endpoint: 'https://slack.com/api/oauth.v2.access'
   slack_post_message_endpoint: 'https://slack.com/api/chat.postMessage'
-  slack_connect_success_url: 'http://localhost:9090/#/manage-team/integrations?auth=ok'
+  slack_team_connect_success_url: 'http://localhost:9090/#/manage-team/integrations?auth=ok'
+  slack_user_connect_success_url: 'http://localhost:9090/#/user?auth=ok'
   slack_auth_endpoint: 'slack.com'
-  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read'
+  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history'
   slack_user_scopes: 'chat:write'
 
 development:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,10 @@ Rails.application.routes.draw do
 
   get "/:team/feed/:rss_token", to: "feed#index"
 
-  get 'auth/slack/:team_id', to: 'slack#auth'
-  get 'auth/callback/slack/:team_id', to: 'slack#auth_callback'
+  get 'auth/slack/user/:user_id', to: 'slack#auth_user'
+  get 'auth/slack/team/:team_id', to: 'slack#auth_team'
+  get 'auth/callback/slack/team/:team_id', to: 'slack#team_auth_callback'
+  get 'auth/callback/slack/user/:user_id', to: 'slack#user_auth_callback'
   post "/slack/kudo", to: 'slack#give_kudos'
   post "/slack/guidelines", to: 'slack#guidelines'
   post "/slack/register", to: 'slack#register'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   get 'auth/callback/slack/user/:user_id', to: 'slack#user_auth_callback'
   post "/slack/kudo", to: 'slack#give_kudos'
   post "/slack/guidelines", to: 'slack#guidelines'
-  post "/slack/register", to: 'slack#register'
+  post "/slack/reaction", to: "slack#reaction"
 
   match "*path" => redirect("/"), via: :get
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   get 'auth/callback/slack/user/:user_id', to: 'slack#user_auth_callback'
   post "/slack/kudo", to: 'slack#give_kudos'
   post "/slack/guidelines", to: 'slack#guidelines'
-  post "/slack/reaction", to: "slack#reaction"
+  post "/slack/event", to: "slack#event"
 
   match "*path" => redirect("/"), via: :get
 end

--- a/db/migrate/20200515050516_add_slack_access_token_to_user.rb
+++ b/db/migrate/20200515050516_add_slack_access_token_to_user.rb
@@ -1,0 +1,6 @@
+class AddSlackAccessTokenToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :slack_access_token, :string
+    remove_column :users, :slack_registration_token
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -675,7 +675,7 @@ CREATE TABLE public.users (
     restricted boolean DEFAULT false,
     company_user boolean DEFAULT false,
     virtual_user boolean DEFAULT false NOT NULL,
-    slack_registration_token character varying
+    slack_access_token character varying
 );
 
 
@@ -1387,6 +1387,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181115082522'),
 ('20181119090637'),
 ('20181128140306'),
-('20200415130431');
+('20200415130431'),
+('20200515050516');
 
 

--- a/spec/requests/slack_request_spec.rb
+++ b/spec/requests/slack_request_spec.rb
@@ -10,84 +10,44 @@ RSpec.describe "Slack" do
     users.each { |user| team.add_member(user) }
   end
 
-  describe 'register' do
-    it 'connects the kudo-o-matic account to Slack' do
+  describe 'user auth callback' do
+    it 'Redirects to the correct url if the request is successful' do
+      allow(SlackService).to receive(:connect_account).and_return(true)
       payload = {
-          text: user.slack_registration_token,
-          user_id: 'fakeSlackId'
+          token: 'fakeToken'
       }
 
-      post '/slack/register', :params => payload
+      get '/auth/callback/slack/user/1', :params => payload
 
-      expect(response.status).to be(200)
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['text']).to eq('Account successfully linked!')
+      expect(response.status).to be(302)
+      expect(response).to redirect_to(Settings.slack_user_connect_success_url)
     end
 
-    it 'returns an error if no token is provided' do
+    it 'returns an error if the request fails' do
+      allow(SlackService).to receive(:connect_account).and_raise(SlackService::InvalidRequest, 'The error description')
       payload = {
-          text: '',
-          user_id: 'fakeSlackId'
+          token: 'fakeToken'
       }
 
-      post '/slack/register', :params => payload
+      get '/auth/callback/slack/user/1', :params => payload
 
       expect(response.status).to be(200)
       parsed_body = JSON.parse(response.body)
-      expect(parsed_body['text']).to eq("That didn't quite work, please provide a register token")
-    end
-
-    it 'returns an error if no user id is provided' do
-      payload = {
-          text: 'token',
-          user_id: ''
-      }
-
-      post '/slack/register', :params => payload
-
-      expect(response.status).to be(200)
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['text']).to eq("That didn't quite work, Invalid registration token")
-    end
-
-    it 'returns an error if the token is invalid' do
-      payload = {
-          text: 'fakeToken',
-          user_id: 'fakeSlackId'
-      }
-
-      post '/slack/register', :params => payload
-
-      expect(response.status).to be(200)
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['text']).to eq("That didn't quite work, Invalid registration token")
-    end
-
-    it 'returns an error if the user is already connected to slack' do
-      payload = {
-          text: user.slack_registration_token,
-          user_id: userWithSlackId.slack_id
-      }
-
-      post '/slack/register', :params => payload
-
-      expect(response.status).to be(200)
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['text']).to eq("That didn't quite work, This slack account is already linked to kudo-o-matic")
+      expect(parsed_body['text']).to eq("That didn't quite work, The error description")
     end
   end
 
-  describe 'auth callback' do
+  describe 'team auth callback' do
     it 'Redirects to the correct url if the request is successful' do
       allow(SlackService).to receive(:add_to_workspace).and_return(true)
       payload = {
           token: 'fakeToken'
       }
 
-      get '/auth/callback/slack/1', :params => payload
+      get '/auth/callback/slack/team/1', :params => payload
 
       expect(response.status).to be(302)
-      expect(response).to redirect_to(Settings.slack_connect_success_url)
+      expect(response).to redirect_to(Settings.slack_team_connect_success_url)
     end
 
     it 'returns an error if the request fails' do
@@ -96,7 +56,7 @@ RSpec.describe "Slack" do
           token: 'fakeToken'
       }
 
-      get '/auth/callback/slack/1', :params => payload
+      get '/auth/callback/slack/team/1', :params => payload
 
       expect(response.status).to be(200)
       parsed_body = JSON.parse(response.body)
@@ -166,6 +126,22 @@ RSpec.describe "Slack" do
       parsed_body = JSON.parse(response.body)
       expect(parsed_body['blocks']).to_not be_nil
 
+    end
+  end
+
+  describe 'auth team' do
+    it 'redirect to different url' do
+      get '/auth/slack/team/1'
+
+      expect(response.status).to be(302)
+    end
+  end
+
+  describe 'auth user' do
+    it 'redirect to different url' do
+      get '/auth/slack/user/1'
+
+      expect(response.status).to be(302)
     end
   end
 end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe 'SlackService' do
 
       SlackService.should_not_receive(:message_is_kudo_o_matic_post?)
 
-      SlackService.reaction_added(team.id, event)
+      SlackService.reaction_added(team.id, event.as_json)
     end
 
     it 'continues if it is a supported emoji' do
@@ -347,7 +347,7 @@ RSpec.describe 'SlackService' do
       allow(SlackService).to receive(:get_message_from_event)
 
       expect(SlackService).to receive(:message_is_kudo_o_matic_post?)
-      SlackService.reaction_added(team.id, event)
+      SlackService.reaction_added(team.id, event.as_json)
     end
 
     it 'likes the post if the message is a kudo-o-matic post' do
@@ -364,11 +364,11 @@ RSpec.describe 'SlackService' do
       }
 
       allow(SlackService).to receive(:supported_emoji?).and_return(true)
-      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock.as_json)
       allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(true)
 
       expect {
-        SlackService.reaction_added(team.id, event)
+        SlackService.reaction_added(team.id, event.as_json)
       }.to change { post.votes.count }.by(1)
 
     end
@@ -387,14 +387,14 @@ RSpec.describe 'SlackService' do
       }
 
       allow(SlackService).to receive(:supported_emoji?).and_return(true)
-      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock.as_json)
       allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(false)
       allow(SlackService).to receive(:send_post_announcement)
       allow(SlackService).to receive(:update_message_to_post).and_return(true)
 
       expect(SlackService).to receive(:update_message_to_post)
       expect {
-        SlackService.reaction_added(team_with_slack.slack_team_id, event)
+        SlackService.reaction_added(team_with_slack.slack_team_id, event.as_json)
       }.to change { Post.count }.by(1)
     end
   end
@@ -407,7 +407,7 @@ RSpec.describe 'SlackService' do
 
       SlackService.should_not_receive(:message_is_kudo_o_matic_post?)
 
-      SlackService.reaction_removed(team.id, event)
+      SlackService.reaction_removed(team.id, event.as_json)
     end
 
     it 'continues if it is a supported emoji' do
@@ -420,7 +420,7 @@ RSpec.describe 'SlackService' do
       allow(SlackService).to receive(:get_message_from_event)
 
       expect(SlackService).to receive(:message_is_kudo_o_matic_post?)
-      SlackService.reaction_removed(team.id, event)
+      SlackService.reaction_removed(team.id, event.as_json)
     end
 
     it 'unlikes the post if it is liked by the user' do
@@ -437,11 +437,11 @@ RSpec.describe 'SlackService' do
           ]
       }
 
-      allow(SlackService).to receive(:get_message_from_event).and_return(message)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message.as_json)
       post.liked_by(user_with_slack_id)
 
       expect {
-        SlackService.reaction_removed(team_with_slack.slack_team_id, event)
+        SlackService.reaction_removed(team_with_slack.slack_team_id, event.as_json)
       }.to change { post.votes.count }.by(-1)
     end
 
@@ -459,10 +459,10 @@ RSpec.describe 'SlackService' do
           ]
       }
 
-      allow(SlackService).to receive(:get_message_from_event).and_return(message)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message.as_json)
 
       expect {
-        SlackService.reaction_removed(team_with_slack.slack_team_id, event)
+        SlackService.reaction_removed(team_with_slack.slack_team_id, event.as_json)
       }.to_not change { post.votes.count }
     end
   end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe 'SlackService' do
     it 'sets the query parameters' do
       uri = SlackService.get_team_oauth_url('1')
 
-      parsed_query = CGI::parse(uri.query)
+      parsed_query = CGI::parse(uri.partition('?').last)
       expect(parsed_query['scope'][0]).to eq('chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join')
       expect(parsed_query['client_id'][0]).to eq('slack-client-id')
       expect(parsed_query['redirect_uri'][0]).to eq('http://backend-domain.com/auth/callback/slack/team/1')
@@ -319,7 +319,7 @@ RSpec.describe 'SlackService' do
     it 'sets the query parameters' do
       uri = SlackService.get_user_oauth_url('1')
 
-      parsed_query = CGI::parse(uri.query)
+      parsed_query = CGI::parse(uri.partition('?').last)
       expect(parsed_query['user_scope'][0]).to eq('chat:write')
       expect(parsed_query['client_id'][0]).to eq('slack-client-id')
       expect(parsed_query['redirect_uri'][0]).to eq('http://backend-domain.com/auth/callback/slack/user/1')

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe 'SlackService' do
   let(:team_with_slack) { create(:team, :with_slack) }
   let(:user) { create(:user) }
   let(:user_with_slack_id) { create(:user, :with_slack_id) }
+  let(:post) { create(:post, sender: user, receivers: [user_with_slack_id], team: team, kudos_meter: team.active_kudos_meter) }
 
   def create_add_post_command(receivers, message, amount)
     command = ""
@@ -20,7 +21,6 @@ RSpec.describe 'SlackService' do
 
   describe 'add to workspace' do
     it 'updates the team channel id, access token and slack id' do
-      allow_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage)
       mock_response = {
           :incoming_webhook => {
               :channel_id => 'channelId'
@@ -32,6 +32,8 @@ RSpec.describe 'SlackService' do
       }
 
       allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(mock_response.as_json)
+      SlackService.should_receive(:send_welcome_message)
+      SlackService.should_receive(:join_all_channels)
 
       expect {
         SlackService.add_to_workspace('token', team.id)
@@ -51,39 +53,57 @@ RSpec.describe 'SlackService' do
   end
 
   describe 'connect account' do
-    it 'updates the slack id and registration token' do
+    before do
+      mock_response = {
+          authed_user: {
+              access_token: 'accessToken',
+              id: 'someSlackId'
+          }
+      }
+
+      allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(mock_response.as_json)
+    end
+
+    it 'updates the slack id and access token' do
+
       expect {
-        SlackService.connect_account(user.slack_registration_token, 'slackId')
+        SlackService.connect_account('token', user.id)
         user.reload
-      }.to change(user, :slack_id).from(nil).to('slackId')
-               .and change(user, :slack_registration_token).from(user.slack_registration_token).to(nil)
+      }.to change(user, :slack_id).from(nil).to('someSlackId')
+               .and change(user, :slack_access_token).from(nil).to('accessToken')
     end
 
     it 'raises an error if there is no token' do
       expect {
-        SlackService.connect_account('', 'slackId')
-      }.to raise_exception(SlackService::InvalidCommand, 'please provide a register token')
+        SlackService.connect_account(nil, 'slackId')
+      }.to raise_exception(SlackService::InvalidCommand, 'Missing auth token')
+    end
+
+    it 'raises an error if there is no user id' do
+      expect {
+        SlackService.connect_account('code', nil)
+      }.to raise_exception(SlackService::InvalidCommand, 'Missing user id')
     end
 
     it 'raises an error if the slack id is already connected to a user' do
-      expect {
-        SlackService.connect_account(user.slack_registration_token,
-                                     user_with_slack_id.slack_id)
-      }.to raise_exception(SlackService::InvalidCommand, 'This slack account is already linked to kudo-o-matic')
-    end
+      mock_response = {
+          authed_user: {
+              access_token: 'accessToken',
+              id: 'fakeSlackId'
+          }
+      }
 
-    it 'returns an error if there is no user for the provided registration token' do
+      allow_any_instance_of(Slack::Web::Client).to receive(:oauth_v2_access).and_return(mock_response.as_json)
+
       expect {
-        SlackService.connect_account('invalidRegisterToken',
-                                     'slackId')
-      }.to raise_exception(SlackService::InvalidCommand, 'Invalid registration token')
+        SlackService.connect_account('code', user.id)
+      }.to raise_exception(SlackService::InvalidCommand, 'This Slack account is already linked to Kudo-O-Matic')
     end
 
     it 'returns an error if the user is already connected to slack' do
       expect {
-        SlackService.connect_account(user_with_slack_id.slack_registration_token,
-                                     'otherSlackId')
-      }.to raise_exception(SlackService::InvalidCommand, 'This kudo-o-matic account is already linked to Slack')
+        SlackService.connect_account('token', user_with_slack_id.id)
+      }.to raise_exception(SlackService::InvalidCommand, 'This Kudo-O-Matic account is already linked to Slack')
     end
   end
 
@@ -91,9 +111,26 @@ RSpec.describe 'SlackService' do
     it 'has the correct message' do
       post = create(:post, sender: user, receivers: [user_with_slack_id], team: team, kudos_meter: team.active_kudos_meter)
 
-      text = "#{user.name} just gave #{post.amount} kudos to <@#{user_with_slack_id.slack_id}> for #{post.message}"
+      message = "#{user.name} just gave #{post.amount} kudos to <@#{user_with_slack_id.slack_id}> for #{post.message}"
+      blocks = [
+          {
+              type: 'section',
+              text: {
+                  type: 'mrkdwn',
+                  text: message
+              }
+          },
+          {
+              type: 'context',
+              block_id: post.id.to_s,
+              elements: [
+                  type: 'mrkdwn',
+                  text: '_This message is a Kudo-O-Matic post_'
+              ]
+          }
+      ]
 
-      expect_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage).with(channel: nil, text: text)
+      expect_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage).with(channel: nil, blocks: blocks)
       SlackService.send_post_announcement(post)
     end
 
@@ -101,7 +138,7 @@ RSpec.describe 'SlackService' do
       team.channel_id = 'slackChannelId'
       post = create(:post, sender: user, receivers: [user_with_slack_id], team: team, kudos_meter: team.active_kudos_meter)
 
-      expect_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage).with(channel: 'slackChannelId', text: anything)
+      expect_any_instance_of(Slack::Web::Client).to receive(:chat_postMessage).with(channel: 'slackChannelId', blocks: anything)
       SlackService.send_post_announcement(post)
     end
   end
@@ -238,6 +275,195 @@ RSpec.describe 'SlackService' do
 
       expect(response.length).to be(1)
       expect(response[0][:text][:text]).to eq("• #{guideline.name} *#{guideline.kudos}* \n")
+    end
+  end
+
+  describe 'get team oauth url' do
+    before do
+      allow(ENV).to receive(:[]).with("SLACK_CLIENT_ID").and_return("slack-client-id")
+      allow(ENV).to receive(:[]).with("SLACK_CLIENT_SECRET").and_return("slack-client-secret")
+      allow(ENV).to receive(:[]).with("ROOT_URL").and_return("backend-domain.com")
+    end
+
+    it 'calls the generate base method' do
+      mock_uri = URI::HTTP.build(host: 'fakedomain.com')
+      SlackService.should_receive(:generate_base_oauth_url).and_return(mock_uri)
+
+      SlackService.get_team_oauth_url('1')
+    end
+
+    it 'sets the query parameters' do
+      uri = SlackService.get_team_oauth_url('1')
+
+      parsed_query = CGI::parse(uri.query)
+      expect(parsed_query['scope'][0]).to eq('chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join')
+      expect(parsed_query['client_id'][0]).to eq('slack-client-id')
+      expect(parsed_query['redirect_uri'][0]).to eq('http://backend-domain.com/auth/callback/slack/team/1')
+    end
+  end
+
+  describe 'get user oauth url' do
+    before do
+      allow(ENV).to receive(:[]).with("SLACK_CLIENT_ID").and_return("slack-client-id")
+      allow(ENV).to receive(:[]).with("SLACK_CLIENT_SECRET").and_return("slack-client-secret")
+      allow(ENV).to receive(:[]).with("ROOT_URL").and_return("backend-domain.com")
+    end
+
+    it 'calls the generate base method' do
+      mock_uri = URI::HTTP.build(host: 'fakedomain.com')
+      SlackService.should_receive(:generate_base_oauth_url).and_return(mock_uri)
+
+      SlackService.get_user_oauth_url('1')
+    end
+
+    it 'sets the query parameters' do
+      uri = SlackService.get_user_oauth_url('1')
+
+      parsed_query = CGI::parse(uri.query)
+      expect(parsed_query['user_scope'][0]).to eq('chat:write')
+      expect(parsed_query['client_id'][0]).to eq('slack-client-id')
+      expect(parsed_query['redirect_uri'][0]).to eq('http://backend-domain.com/auth/callback/slack/user/1')
+    end
+  end
+
+  describe 'reaction added' do
+    it 'returns if it is a unsupported emoji' do
+      event = {
+          reaction: 'unsopperted-emoji'
+      }
+
+      SlackService.should_not_receive(:message_is_kudo_o_matic_post?)
+
+      SlackService.reaction_added(team.id, event)
+    end
+
+    it 'continues if it is a supported emoji' do
+      event = {
+          reaction: 'kudos-development'
+      }
+
+      allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(true)
+      allow(SlackService).to receive(:like_post)
+      allow(SlackService).to receive(:get_message_from_event)
+
+      expect(SlackService).to receive(:message_is_kudo_o_matic_post?)
+      SlackService.reaction_added(team.id, event)
+    end
+
+    it 'likes the post if the message is a kudo-o-matic post' do
+      event = {
+          user: user_with_slack_id.slack_id,
+      }
+
+      message_mock = {
+          blocks: [
+              {
+                  block_id: post.id.to_s
+              }
+          ]
+      }
+
+      allow(SlackService).to receive(:supported_emoji?).and_return(true)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock)
+      allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(true)
+
+      expect {
+        SlackService.reaction_added(team.id, event)
+      }.to change { post.votes.count }.by(1)
+
+    end
+
+    it 'creates a post if the message is not a kudo-o-matic post' do
+      event = {
+          user: user_with_slack_id.slack_id,
+          item: {
+              channel: 'channelId'
+          }
+      }
+
+      message_mock = {
+          user: user_with_slack_id.slack_id,
+          text: 'Some text'
+      }
+
+      allow(SlackService).to receive(:supported_emoji?).and_return(true)
+      allow(SlackService).to receive(:get_message_from_event).and_return(message_mock)
+      allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(false)
+      allow(SlackService).to receive(:send_post_announcement)
+      allow(SlackService).to receive(:update_message_to_post).and_return(true)
+
+      expect(SlackService).to receive(:update_message_to_post)
+      expect {
+        SlackService.reaction_added(team_with_slack.slack_team_id, event)
+      }.to change { Post.count }.by(1)
+    end
+  end
+
+  describe 'reaction_removed' do
+    it 'returns if it is a unsupported emoji' do
+      event = {
+          reaction: 'unsopperted-emoji'
+      }
+
+      SlackService.should_not_receive(:message_is_kudo_o_matic_post?)
+
+      SlackService.reaction_removed(team.id, event)
+    end
+
+    it 'continues if it is a supported emoji' do
+      event = {
+          reaction: 'kudos-development'
+      }
+
+      allow(SlackService).to receive(:message_is_kudo_o_matic_post?).and_return(true)
+      allow(SlackService).to receive(:unlike_post)
+      allow(SlackService).to receive(:get_message_from_event)
+
+      expect(SlackService).to receive(:message_is_kudo_o_matic_post?)
+      SlackService.reaction_removed(team.id, event)
+    end
+
+    it 'unlikes the post if it is liked by the user' do
+      event = {
+          reaction: 'kudos-development',
+          user: user_with_slack_id.slack_id
+      }
+
+      message = {
+          blocks: [
+              {
+                  block_id: post.id
+              }
+          ]
+      }
+
+      allow(SlackService).to receive(:get_message_from_event).and_return(message)
+      post.liked_by(user_with_slack_id)
+
+      expect {
+        SlackService.reaction_removed(team_with_slack.slack_team_id, event)
+      }.to change { post.votes.count }.by(-1)
+    end
+
+    it 'does not unlikes the post if it is not liked by the user' do
+      event = {
+          reaction: 'kudos-development',
+          user: user_with_slack_id.slack_id
+      }
+
+      message = {
+          blocks: [
+              {
+                  block_id: post.id
+              }
+          ]
+      }
+
+      allow(SlackService).to receive(:get_message_from_event).and_return(message)
+
+      expect {
+        SlackService.reaction_removed(team_with_slack.slack_team_id, event)
+      }.to_not change { post.votes.count }
     end
   end
 end


### PR DESCRIPTION
- Users can like/dislike kudo-o-matic message posts using emojis
- Users can create posts using emojis
- Connecting Kudo-O-Matic accounts to Slack is now done via OAuth
- Slack events are handled asynchronous with Sidekiq to comply with the [Slack events API](https://api.slack.com/events-api#responding_to_events)

A good next step would be to refactor the SlackService.rb class into smaller modules like auth, message_parsing, etc. 

![example gif](https://i.imgur.com/bmN8wPu.gif)