### PR TITLE
Escape Slack user id's in post message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+### Fixed
+- Escape mentioned users when creating a post via emoji
+
 ## [4.2.1]
 ### Fixed
 - duplicate team memberships

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -213,6 +213,7 @@ class SlackService
   end
 
   def self.create_post_from_message(team, user, slack_message)
+    client = Slack::Web::Client.new(token: team.slack_bot_access_token)
     receiver = User.find_by_slack_id(slack_message['user'])
 
     if receiver.nil?
@@ -221,13 +222,25 @@ class SlackService
 
     raise InvalidRequest.new("That user has not connected their account to Slack.") if receiver == nil
 
-    message = "saying: '#{slack_message['text']}'"
+    message = create_message(client, slack_message)
 
     begin
       PostCreator.create_post(message, 1, user, [receiver], team)
     rescue PostCreator::PostCreateError => e
       raise InvalidCommand.new(e)
     end
+  end
+
+  def self.create_message(slack_client, slack_message)
+    message = "saying: '#{slack_message['text']}'"
+    mentioned_users = message.scan(/(?=<).*?(?<=>)/)
+
+    mentioned_users.each do |mentioned_user|
+      user_info = slack_client.users_info(user: mentioned_user.tr('<>@', ''))
+      message[mentioned_user] = user_info['user']['name']
+    end
+
+    message
   end
 
   def self.update_message_to_post(channel_id, message, post)

--- a/config/application.yml
+++ b/config/application.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   slack_user_connect_success_url: 'http://localhost:9090/#/user?auth=ok'
   slack_accepted_emojis: 'kudos-development'
   slack_auth_endpoint: 'slack.com'
-  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join'
+  slack_scopes: 'chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join,users:read'
   slack_user_scopes: 'chat:write'
   slack_join_all_channels: false
 

--- a/docs/SLACK_INTEGRATION.md
+++ b/docs/SLACK_INTEGRATION.md
@@ -113,6 +113,7 @@ The following bot token scopes need to be added:
 - commands
 - incoming-webhook
 - reactions:read
+- users:read
 
 The following User Token Scopes need to be added:
 - chat:write

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -335,7 +335,7 @@ RSpec.describe 'SlackService' do
       uri = SlackService.get_team_oauth_url('1')
 
       parsed_query = CGI::parse(uri.partition('?').last)
-      expect(parsed_query['scope'][0]).to eq('chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join')
+      expect(parsed_query['scope'][0]).to eq('chat:write,commands,incoming-webhook,chat:write.public,reactions:read,channels:history,channels:read,channels:join,users:read')
       expect(parsed_query['client_id'][0]).to eq('slack-client-id')
       expect(parsed_query['redirect_uri'][0]).to eq('https://backend-domain.com/auth/callback/slack/team/1')
     end


### PR DESCRIPTION
When creating a post via emoji mentioned users would be incorporated into the message with their id. 
This would result in a post message looking like this:
`for saying: 'thanks for helping me <@SOMEID>'`.

This PR escapes all user id's and replaces them with their Slack name.
`for saying: 'thanks for helping me max.meijer'`.
