### PR TITLE
Don't send Slack announcement when giving kudos via emoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Don't send Slack announcement when creating a post via emoji
+
 ## [4.2.1]
 ### Fixed
 - duplicate team memberships

--- a/app/models/post_creator.rb
+++ b/app/models/post_creator.rb
@@ -1,7 +1,7 @@
 class PostCreator
   class PostCreateError < RuntimeError; end
 
-  def self.create_post(message, amount, sender, receivers, team)
+  def self.create_post(message, amount, sender, receivers, team, send_slack_announcement = true)
     post = Post.new(
         message: message,
         amount: amount,
@@ -23,7 +23,11 @@ class PostCreator
     end
 
     PostMailer.new_post(post)
-    SlackService.send_post_announcement(post) unless team.slack_team_id == nil
+
+    if send_slack_announcement && !team.slack_team_id.blank?
+      SlackService.send_post_announcement(post)
+    end
+
     post
   end
 end

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -224,7 +224,7 @@ class SlackService
     message = "saying: '#{slack_message['text']}'"
 
     begin
-      PostCreator.create_post(message, 1, user, [receiver], team)
+      PostCreator.create_post(message, 1, user, [receiver], team, false)
     rescue PostCreator::PostCreateError => e
       raise InvalidCommand.new(e)
     end

--- a/spec/models/post_creator_spec.rb
+++ b/spec/models/post_creator_spec.rb
@@ -39,5 +39,10 @@ RSpec.describe KudosMeter, type: :model do
       expect(SlackService).to_not receive(:send_post_announcement)
       PostCreator.create_post('Some message', 5, user, [other_user], team)
     end
+
+    it 'doesnt send the slack announcement if the option is set to false' do
+      expect(SlackService).to_not receive(:send_post_announcement)
+      PostCreator.create_post('Some message', 5, user, [other_user], team_with_slack, false)
+    end
   end
 end


### PR DESCRIPTION
Don't send a Slack announcement message when a post is created via emoji