### PR TITLE
Add rake task to remove all Slack access tokens

### DIFF
--- a/lib/tasks/slack_tokens.rake
+++ b/lib/tasks/slack_tokens.rake
@@ -1,0 +1,14 @@
+namespace :slack_tokens do
+  desc 'Remove all slack access tokens from users'
+  task :remove => :environment do
+    puts 'Removing all slack access tokens'
+
+    User.all.find_each do |user|
+      user.slack_access_token = nil
+      user.slack_id = nil
+
+      user.save
+    end
+  end
+end
+


### PR DESCRIPTION
There are currently slack access tokens with the wrong permissions which causes some Slack functionality to misbehave.
This rake task will clear all Slack access tokens in the DB which will require users to reconnect their Kudo-O-Matic accounts to Slack.