### PR TITLE
feature/up-build-heroku-actions-dependency

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: akhileshns/heroku-deploy@v3.0.4
+      - uses: akhileshns/heroku-deploy@v3.12.13
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: "kudo-o-matic-staging"


### PR DESCRIPTION
Up dependency since latest staging build seems to fail on this: https://github.com/kabisa/kudo-o-matic/actions/runs/4851436127/jobs/8645329406