### PR TITLE
fix: restore mail delivery (worker crash, asset precompile, switch to AWS SES)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ storage
 dump.rdb
 
 **/.terraform/
+
+# AWS SES credentials (local only, never commit)
+cred

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,3 @@ storage
 dump.rdb
 
 **/.terraform/
-
-# AWS SES credentials (local only, never commit)
-cred

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
-//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,12 +63,13 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "kudo_o_matic_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
-  # SMTP settings for gmail
+  # SMTP settings for AWS SES. SMTP auth credentials are separate from the
+  # From address (MAIL_USERNAME), unlike Gmail where they were the same.
   config.action_mailer.smtp_settings = {
       address: ENV["MAIL_ADDRESS"],
       port: 587,
-      user_name: ENV["MAIL_USERNAME"],
-      password: ENV["MAIL_PASSWORD"],
+      user_name: ENV["SMTP_USERNAME"],
+      password: ENV["SMTP_PASSWORD"],
       authentication: "plain",
       enable_starttls_auto: true
   }

--- a/dockerfiles/production/Dockerfile
+++ b/dockerfiles/production/Dockerfile
@@ -75,6 +75,9 @@ RUN gem install bundler -v 2.3.22
 RUN bundle config set force_ruby_platform true
 RUN bundle install
 
+# Precompile assets so premailer can inline email.css when rendering mail
+RUN SECRET_KEY_BASE=dummy bundle exec rake assets:precompile
+
 FROM base AS web
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 

--- a/dockerfiles/production/Dockerfile
+++ b/dockerfiles/production/Dockerfile
@@ -79,7 +79,7 @@ FROM base AS web
 CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
 
 FROM base AS worker
-CMD ["bundle", "exec", "sidekiq", "-c", "3", "-q", "default", "-q" "mailers"]
+CMD ["bundle", "exec", "sidekiq", "-c", "3", "-q", "default", "-q", "mailers"]
 
 FROM base AS release
 CMD ["bundle", "exec", "rake", "db:migrate"]


### PR DESCRIPTION
## Waarom
Er werd geen mail verstuurd in productie (invites, wachtwoord-reset, welkom, kudo-notificaties). Root cause bleek een keten van drie bugs plus een dode mailserver.

## Wat & waarom

1. **`fix: add missing comma in sidekiq worker CMD`**
   Worker CMD JSON-array miste een komma tussen `"-q"` en `"mailers"` → ongeldige exec-form → Docker viel terug op shell-form → `/bin/sh: 1: [bundle,: not found`, exit 127. Worker-dyno crash-loopte sinds de Docker-migratie (~13,5 mnd). Zonder Sidekiq-worker werd de `mailers`-queue nooit geleegd, dus alle `deliver_later`-mail bleef hangen.

2. **`fix: precompile assets in production image for mailer CSS`**
   Delivery jobs faalden met `Premailer::Rails::CSSHelper::FileNotFound` voor `/stylesheets/email.css`. Het productie-image draaide nooit `assets:precompile` en `config.assets.compile = false`, dus premailer kon de gecompileerde CSS niet inline zetten. Precompile toegevoegd in de base-stage (web én worker hebben het asset nodig; premailer draait in de delivery job op de worker).

3. **`fix: drop JS from asset precompile manifest`**
   `assets:precompile` crashte op `application.js` (`Cannot find module '@babel/runtime/...'`) omdat het image geen JS-toolchain heeft. Dit is een GraphQL API-backend zonder server-rendered JS, dus alleen images en stylesheets compileren.

4. **`feat: switch mail delivery to AWS SES SMTP`**
   Gmail-SMTP-auth werd geweigerd (`535-5.7.8`). Overgestapt naar AWS SES in eu-west-1 (domein-identity `kabisa.io` verified, SPF + DKIM + custom MAIL FROM `mail.kabisa.io` alle Successful, account uit sandbox). SES SMTP-auth-credentials verschillen van het From-adres, dus ontkoppeld: `user_name`/`password` lezen nu `SMTP_USERNAME`/`SMTP_PASSWORD`, `MAIL_USERNAME` blijft het From-adres (`noreply@kabisa.io`).

## Heroku config (al gezet op productie)
- `MAIL_ADDRESS = email-smtp.eu-west-1.amazonaws.com`
- `SMTP_USERNAME` / `SMTP_PASSWORD` = SES SMTP-credentials
- `MAIL_USERNAME = noreply@kabisa.io`
- `MAIL_PASSWORD` (oude Gmail) is nu ongebruikt — kan opgeruimd worden

## Verificatie
End-to-end testmail via de productie-SES-config succesvol afgeleverd (`From: noreply@kabisa.io` → `joost@kabisa.nl`, geen auth-fout). Worker + web dyno's up.

> Let op: deze commits staan al op `master` (direct gepusht om productie snel te herstellen). Deze PR brengt `develop` gelijk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)